### PR TITLE
Release/v1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ My goal with this fork was to maintain the core Crosspoint firmware while integr
 
 - New reader fonts: ChareInk, Lexend Deca, and Bitter
 - Unicode emoji and miscellaneous symbols support
-- Added ~~strikethrough~~ support
+- Added ~~strikethrough~~ support; Made <u>underlines</u> thicker for better visibility
 - Adjusted font sizes: Tiny (10pt), Small (12pt), Medium (14pt), Large (16pt), Extra Large (18pt). See [Font Sizes](#font-sizes) for more details.
 - Added ability to remap front buttons that only applies in the reader
 - In-book menu to quickly adjust font options without having to exit the book
 - Reading stats per book (total reading time, number of sessions, pages turned, average session time)
-- Changed "Auto Turn (Pages Per Minute)" to "Auto Page Turn Interval" since this better describes the feature.
-  - Added additional page turn intervals. Options are now: 60s, 45s (new), 30s (new), 20s, 15s (new), 10s, 5s, OFF.
+- Changed "Auto Turn (Pages Per Minute)" to "Auto Page Turn Interval (seconds)" since this better describes the feature.
+  - Added additional page turn intervals (how many seconds pass between page turns). Options are now (in seconds): 60, 45, 30, 20, 15, 10, 5, OFF.
 - Device simulator during development
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ My goal with this fork was to maintain the core Crosspoint firmware while integr
 
 - New reader fonts: ChareInk, Lexend Deca, and Bitter
 - Unicode emoji and miscellaneous symbols support
-- Added ~~strikethrough~~ support; Made <u>underlines</u> thicker for better visibility
 - Adjusted font sizes: Tiny (10pt), Small (12pt), Medium (14pt), Large (16pt), Extra Large (18pt). See [Font Sizes](#font-sizes) for more details.
+- Added ~~strikethrough~~ support
+- Made <u>underlines</u> thicker for better visibility
 - Added ability to remap front buttons that only applies in the reader
 - In-book menu to quickly adjust font options without having to exit the book
-- Reading stats per book (total reading time, number of sessions, pages turned, average session time)
-- Changed "Auto Turn (Pages Per Minute)" to "Auto Page Turn Interval (seconds)" since this better describes the feature.
+- Reading stats: total reading time, number of sessions, pages turned, average session time, pages turned per minute
+- Changed label for "Auto Turn (Pages Per Minute)" to "Auto Page Turn Interval (seconds)"
   - Added additional page turn intervals (how many seconds pass between page turns). Options are now (in seconds): 60, 45, 30, 20, 15, 10, 5, OFF.
 - Device simulator during development
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ extra_configs = platformio.local.ini
 
 [crosspoint]
 version = 1.2.0
-crossink_version = 1.2.3
+crossink_version = 1.2.4
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
@@ -114,7 +114,7 @@ extends = base
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
-  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-xs\"
+  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-tiny\"
   -DCROSSPOINT_FIRMWARE_VARIANT=\"tiny\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1
@@ -126,7 +126,7 @@ extends = base
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
-  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-xl\"
+  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-xlarge\"
   -DCROSSPOINT_FIRMWARE_VARIANT=\"xlarge\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1
@@ -139,7 +139,7 @@ extends = base
 build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
-  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-ne\"
+  -DCROSSINK_VERSION=\"${crosspoint.crossink_version}-no_emoji\"
   -DCROSSPOINT_FIRMWARE_VARIANT=\"no_emoji\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1

--- a/src/activities/reader/BookStatsActivity.cpp
+++ b/src/activities/reader/BookStatsActivity.cpp
@@ -120,7 +120,7 @@ void BookStatsActivity::render(RenderLock&&) {
   // ─── Card 2: All Books ───────────────────────────────────────────────────────
   // Only rendered if there is enough vertical space before the button hints.
   const int screenHeight = renderer.getScreenHeight();
-  const int card2H = cardTitleH + cellH;
+  const int card2H = cardTitleH + cellH * 2;
   if (screenHeight - y - metrics.buttonHintsHeight - metrics.verticalSpacing >= card2H) {
     renderer.drawRect(cardX, y, cardW, card2H);
 
@@ -139,6 +139,22 @@ void BookStatsActivity::render(RenderLock&&) {
 
     snprintf(buf, sizeof(buf), "%lu", static_cast<unsigned long>(globalStats.totalPagesTurned));
     drawStatCell(cardX + thirdW * 2, thirdW, y, buf, tr(STR_STATS_PAGES_LBL));
+
+    y += cellH;
+
+    const uint32_t globalAvgSecs =
+        globalStats.totalSessions > 0 ? globalStats.totalReadingSeconds / globalStats.totalSessions : 0;
+    BookReadingStats::formatDuration(globalAvgSecs, buf, sizeof(buf));
+    drawStatCell(cardX, halfW, y, buf, tr(STR_STATS_AVG_SESSION_LBL));
+
+    if (globalStats.totalReadingSeconds > 60) {
+      const float ppm = static_cast<float>(globalStats.totalPagesTurned) * 60.0f /
+                        static_cast<float>(globalStats.totalReadingSeconds);
+      snprintf(buf, sizeof(buf), "%.1f", ppm);
+    } else {
+      snprintf(buf, sizeof(buf), "0.0");
+    }
+    drawStatCell(cardX + halfW, halfW, y, buf, tr(STR_STATS_PAGES_PER_MIN));
   }
 
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");


### PR DESCRIPTION
## Summary

- The label for "Auto Page Turns (Pages per Minute)" now reads as "Auto Page Turn Interval (seconds)", so now you just choose how quickly you want the page to automatically turn, which I think is more intuitive.
- Adds 3 new auto page turn intervals: 15 seconds, 30 seconds, 45 seconds.
- Reading Stats for "All Books" now matches the stats per book.
- Minor UI update to Reading Stats view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README with expanded reading statistics and revised "Auto Page Turn Interval" control with seconds-based options (60, 45, 30, 20, 15, 10, 5, OFF).

* **New Features**
  * Added pages-per-minute and average session duration metrics to Book Stats display.

* **Chores**
  * Version bumped to 1.2.4. Updated build configuration naming for environment variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->