### PR TITLE
Fix simulator sleep screen rendering

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -451,7 +451,7 @@ size_t BookMetadataCache::getSpineCumulativeSize(const int index) {
   serialization::readPod(bookFile, hrefLen);
   bookFile.seekCur(hrefLen);
 
-  size_t cumulativeSize = 0;
+  uint32_t cumulativeSize = 0; // simulator patch
   serialization::readPod(bookFile, cumulativeSize);
   return cumulativeSize;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,6 +265,10 @@ void enterDeepSleep() {
 
   activityManager.goToSleep();
 
+#ifdef SIMULATOR
+  display.presentIfNeeded();
+#endif
+
   display.deepSleep();
   LOG_DBG("MAIN", "Entering deep sleep");
 


### PR DESCRIPTION
## Summary

- **Issue**

In simulator mode, entering sleep left the window visually stuck on the previous screen instead of showing the sleep screen.

- **What changes are included?**

In simulator mode, the sleep screen was rendered but never shown because `displayBuffer()` only queued an SDL present. `enterDeepSleep()` then immediately entered the simulator’s blocking deep-sleep loop, so `display.presentIfNeeded()` in the main loop never ran.

This explicitly flushes the pending simulator frame after `activityManager.goToSleep()` and before entering simulated deep sleep. The change is guarded with `#ifdef SIMULATOR`, so hardware behavior is unchanged.

- **Type fixed**

In simulator mode, EPUB progress data could be read incorrectly because `cumulativeSize` was loaded as `size_t`. On macOS `size_t` is 64-bit, but the cache stores the value as 32-bit, so reading it consumed extra bytes and corrupted the parsed cache position.


Fixed using Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved simulator accuracy for book metadata caching operations.
* Enhanced display behavior in simulator deep sleep mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->