### PR TITLE
Fix: avoid pop redraw while render-locked

### DIFF
--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -8,7 +8,7 @@ void Activity::onExit() { LOG_DBG("ACT", "Exiting activity: %s", name.c_str()); 
 
 void Activity::requestUpdate(bool immediate) { activityManager.requestUpdate(immediate); }
 
-void Activity::requestUpdateAndWait() { activityManager.requestUpdateAndWait(); }
+RequestUpdateResult Activity::requestUpdateAndWait() { return activityManager.requestUpdateAndWait(); }
 
 void Activity::onGoHome() { activityManager.goHome(); }
 

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -39,7 +39,7 @@ class Activity {
   virtual void requestUpdate(bool immediate = false);
 
   // Request an immediate render and block until it completes.
-  virtual void requestUpdateAndWait();
+  virtual RequestUpdateResult requestUpdateAndWait();
 
   virtual bool skipLoopDelay() { return false; }
   virtual bool preventAutoSleep() { return false; }

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -46,10 +46,10 @@ void ActivityManager::renderTaskLoop() {
     }
     // Notify any task blocked in requestUpdateAndWait() that the render is done.
     TaskHandle_t waiter = nullptr;
-    taskENTER_CRITICAL(nullptr);
+    taskENTER_CRITICAL(&renderStateMux);
     waiter = waitingTaskHandle;
     waitingTaskHandle = nullptr;
-    taskEXIT_CRITICAL(nullptr);
+    taskEXIT_CRITICAL(&renderStateMux);
     if (waiter) {
       xTaskNotify(waiter, 1, eIncrement);
     }
@@ -103,9 +103,11 @@ void ActivityManager::loop() {
           handler(pendingResult);
         }
 
-        // Request an update to ensure the popped activity gets re-rendered
+        // Queue an update to ensure the popped activity gets re-rendered.
+        // This path does not require the redraw to complete before loop() continues.
         if (pendingAction == PendingAction::None) {
-          requestUpdateAndWait();
+          lock.unlock();
+          requestUpdate();
         }
 
         // Handler may request another pending action, we will handle it in the next loop iteration
@@ -268,13 +270,13 @@ void ActivityManager::requestUpdate(bool immediate) {
     requestedUpdate = true;
   }
 }
-void ActivityManager::requestUpdateAndWait() {
+RequestUpdateResult ActivityManager::requestUpdateAndWait() {
   if (!renderTaskHandle) {
-    return;
+    return RequestUpdateResult::Rejected;
   }
 
   // Atomic section to perform checks
-  taskENTER_CRITICAL(nullptr);
+  taskENTER_CRITICAL(&renderStateMux);
   auto currTaskHandler = xTaskGetCurrentTaskHandle();
   auto mutexHolder = xSemaphoreGetMutexHolder(renderingMutex);
   bool isRenderTask = (currTaskHandler == renderTaskHandle);
@@ -283,19 +285,27 @@ void ActivityManager::requestUpdateAndWait() {
   if (!alreadyWaiting && !isRenderTask && !holdingRenderLock) {
     waitingTaskHandle = currTaskHandler;
   }
-  taskEXIT_CRITICAL(nullptr);
+  taskEXIT_CRITICAL(&renderStateMux);
 
-  // Render task cannot call requestUpdateAndWait() or it will cause a deadlock
-  assert(!isRenderTask && "Render task cannot call requestUpdateAndWait()");
+  if (isRenderTask) {
+    LOG_ERR("ACT", "requestUpdateAndWait() called from render task; rejecting sync update");
+    return RequestUpdateResult::Rejected;
+  }
 
-  // There should never be the case where 2 tasks are waiting for a render at the same time
-  assert(!alreadyWaiting && "Already waiting for a render to complete");
+  if (alreadyWaiting) {
+    LOG_ERR("ACT", "requestUpdateAndWait() called while another task is waiting; rejecting sync update");
+    return RequestUpdateResult::Rejected;
+  }
 
   // Cannot call while holding RenderLock or it will cause a deadlock
-  assert(!holdingRenderLock && "Cannot call requestUpdateAndWait() while holding RenderLock");
+  if (holdingRenderLock) {
+    LOG_ERR("ACT", "requestUpdateAndWait() called while holding RenderLock; rejecting sync update");
+    return RequestUpdateResult::Rejected;
+  }
 
   xTaskNotify(renderTaskHandle, 1, eIncrement);
   ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+  return RequestUpdateResult::Rendered;
 }
 
 // RenderLock

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -13,8 +13,16 @@
 #include "MappedInputManager.h"
 #include "util/ScreenshotInfo.h"
 
+#ifndef portMUX_INITIALIZER_UNLOCKED
+struct portMUX_TYPE {};
+#define portMUX_INITIALIZER_UNLOCKED \
+  {}
+#endif
+
 class Activity;    // forward declaration
 class RenderLock;  // forward declaration
+
+enum class RequestUpdateResult { Rendered, Rejected };
 
 /**
  * ActivityManager
@@ -54,6 +62,7 @@ class ActivityManager {
   // Set by requestUpdateAndWait(); read and cleared by the render task after render completes.
   // Note: only one waiting task is supported at a time
   TaskHandle_t waitingTaskHandle = nullptr;
+  portMUX_TYPE renderStateMux = portMUX_INITIALIZER_UNLOCKED;
 
   // Mutex to protect rendering operations from race conditions
   // Must only be used via RenderLock
@@ -108,8 +117,9 @@ class ActivityManager {
   void requestUpdate(bool immediate = false);
 
   // Trigger a render and block until it completes.
-  // Must NOT be called from the render task or while holding a RenderLock.
-  void requestUpdateAndWait();
+  // Returns Rejected when a synchronous render would be unsafe, such as from the render task,
+  // while another task is already waiting, or while holding a RenderLock.
+  RequestUpdateResult requestUpdateAndWait();
 };
 
 extern ActivityManager activityManager;  // singleton, to be defined in main.cpp

--- a/src/activities/home/AlertActivity.cpp
+++ b/src/activities/home/AlertActivity.cpp
@@ -11,7 +11,9 @@ void AlertActivity::onEnter() {
   Activity::onEnter();
   title = APP_STATE.pendingAlertTitle;
   body = APP_STATE.pendingAlertBody;
-  requestUpdateAndWait();
+  if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+    LOG_ERR("ALERT", "Alert screen could not be rendered synchronously");
+  }
 }
 
 void AlertActivity::loop() {

--- a/src/activities/home/CrashActivity.cpp
+++ b/src/activities/home/CrashActivity.cpp
@@ -16,7 +16,9 @@ void CrashActivity::onEnter() {
   }
   HalSystem::clearPanic();
 
-  requestUpdateAndWait();
+  if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+    LOG_ERR("CRASH", "Crash screen could not be rendered synchronously");
+  }
 }
 
 void CrashActivity::loop() {

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -115,7 +115,17 @@ void KOReaderSyncActivity::performSync() {
     RenderLock lock(*this);
     statusMessage = tr(STR_FETCH_PROGRESS);
   }
-  requestUpdateAndWait();
+  if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+    LOG_ERR("KOSync", "Fetch progress screen could not be rendered synchronously; aborting sync");
+    wifiOff();
+    {
+      RenderLock lock(*this);
+      state = SYNC_FAILED;
+      statusMessage = "Render update failed";
+    }
+    requestUpdate(true);
+    return;
+  }
 
   // Fetch remote progress
   const auto result = KOReaderSyncClient::getProgress(documentHash, remoteProgress);
@@ -183,7 +193,17 @@ void KOReaderSyncActivity::performUpload() {
     state = UPLOADING;
     statusMessage = tr(STR_UPLOAD_PROGRESS);
   }
-  requestUpdateAndWait();
+  if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+    LOG_ERR("KOSync", "Upload progress screen could not be rendered synchronously; aborting upload");
+    wifiOff();
+    {
+      RenderLock lock(*this);
+      state = SYNC_FAILED;
+      statusMessage = "Render update failed";
+    }
+    requestUpdate(true);
+    return;
+  }
 
   // Convert current position to KOReader format
   CrossPointPosition localPos =

--- a/src/activities/settings/ClearCacheActivity.cpp
+++ b/src/activities/settings/ClearCacheActivity.cpp
@@ -127,7 +127,15 @@ void ClearCacheActivity::loop() {
         RenderLock lock(*this);
         state = CLEARING;
       }
-      requestUpdateAndWait();
+      if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+        LOG_ERR("CLEAR_CACHE", "Clearing cache screen could not be rendered synchronously; aborting cache clear");
+        {
+          RenderLock lock(*this);
+          state = FAILED;
+        }
+        requestUpdate(true);
+        return;
+      }
 
       clearCache();
     }

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -24,7 +24,15 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
     RenderLock lock(*this);
     state = CHECKING_FOR_UPDATE;
   }
-  requestUpdateAndWait();
+  if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+    LOG_ERR("OTA", "Checking update screen could not be rendered synchronously; aborting update check");
+    {
+      RenderLock lock(*this);
+      state = FAILED;
+    }
+    requestUpdate(true);
+    return;
+  }
 
   const auto res = updater.checkForUpdate();
   if (res != OtaUpdater::OK) {
@@ -33,6 +41,7 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
       RenderLock lock(*this);
       state = FAILED;
     }
+    requestUpdate(true);
     return;
   }
 
@@ -42,6 +51,7 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
       RenderLock lock(*this);
       state = NO_UPDATE;
     }
+    requestUpdate(true);
     return;
   }
 
@@ -49,6 +59,7 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
     RenderLock lock(*this);
     state = WAITING_CONFIRMATION;
   }
+  requestUpdate(true);
 }
 
 void OtaUpdateActivity::onEnter() {
@@ -147,7 +158,15 @@ void OtaUpdateActivity::loop() {
         RenderLock lock(*this);
         state = UPDATE_IN_PROGRESS;
       }
-      requestUpdateAndWait();
+      if (requestUpdateAndWait() != RequestUpdateResult::Rendered) {
+        LOG_ERR("OTA", "Update progress screen could not be rendered synchronously; aborting OTA install");
+        {
+          RenderLock lock(*this);
+          state = FAILED;
+        }
+        requestUpdate(true);
+        return;
+      }
       const auto res = updater.installUpdate(
           [](void* ctx) {
             // immediate=true notifies the render task directly. The default deferred path only
@@ -171,9 +190,13 @@ void OtaUpdateActivity::loop() {
         RenderLock lock(*this);
         state = FINISHED;
       }
-      requestUpdateAndWait();
-      // Hold the completion screen briefly so the user sees it, then restart.
-      delay(3000);
+      const auto renderResult = requestUpdateAndWait();
+      if (renderResult == RequestUpdateResult::Rendered) {
+        // Hold the completion screen briefly so the user sees it, then restart.
+        delay(3000);
+      } else {
+        LOG_ERR("OTA", "Completion screen could not be rendered synchronously; restarting without sync confirmation");
+      }
       {
         RenderLock lock(*this);
         state = SHUTTING_DOWN;


### PR DESCRIPTION
## Summary

Fix for crash on return from "Reader Options" in book reading mode. 

Tested only on the simulator. 

- **What changes are included?**

Queue the post-pop redraw instead of waiting for it while unwinding nested activities, which avoids the Reader Options back-path render-lock assertion.

Make `requestUpdateAndWait()` report whether a synchronous render completed or was rejected, and update blocking callers to handle rejected sync renders explicitly instead of relying on an implicit async fallback.

Codex were involved in the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented UI hangs and improved stability during activity transitions and rendering to avoid deadlocks and unresponsiveness.
  * Activities now detect failed synchronous screen renders (alerts, crash, sync/progress, clear-cache, OTA), log errors, and fall back to safe async updates so flows continue.
  * Improved responsiveness by queuing async updates when synchronous renders are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->