### PR TITLE
feat: allow simple EPUB tables with full-width note rows so a single …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
+### Changed
+
+
 ### Added
+- New Lyra Carousel theme that displays 3 of your most recent book covers
 - Prevent a crash when entering sleep with Page Overlay enabled if the cached EPUB page data is invalid
 - Clean up EPUB table rendering by removing synthetic row/cell labels and defaulting table cells to readable left alignment
-- Improve simple EPUB tables by buffering them into multi-column grid fragments instead of rendering each cell as an unrelated paragraph
+- Allow simple EPUB tables with full-width note rows so a single `colspan` cell spanning the whole table no longer forces the entire table back to paragraph fallback
 
 ### Fixed
-- Fix a crash when opening EPUB chapters that continue with normal text after a buffered table
 - Fix a crash when using `Go to %` in EPUBs by serializing the jump calculation with other reader cache access
 - Fix OTA update checks after the streaming release parser merge by keeping variant-aware firmware asset matching

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -9,6 +9,7 @@
 #include <XmlParserUtils.h>
 #include <expat.h>
 
+#include <cstdlib>
 #include <new>
 
 #include "../../Epub.h"
@@ -198,6 +199,7 @@ void ChapterHtmlSlimParser::finalizeCurrentTableCell() {
 
   BufferedTableCell cell;
   cell.isHeader = currentTableCellIsHeader;
+  cell.colSpan = currentTableCellColSpan;
   cell.text = std::move(currentTextBlock);
   cell.footnotes = std::move(pendingFootnotes);
   pendingFootnotes.clear();
@@ -209,16 +211,18 @@ void ChapterHtmlSlimParser::finalizeCurrentTableCell() {
   auto& row = currentTableBuffer->rows.back();
   row.hasHeaderCell = row.hasHeaderCell || cell.isHeader;
   row.hasDataCell = row.hasDataCell || !cell.isHeader;
+  row.effectiveColumnCount = static_cast<uint16_t>(row.effectiveColumnCount + cell.colSpan);
   row.cells.push_back(std::move(cell));
 
   currentTableBuffer->totalCells++;
-  currentTableBuffer->maxCols = std::max<uint16_t>(currentTableBuffer->maxCols, row.cells.size());
+  currentTableBuffer->maxCols = std::max<uint16_t>(currentTableBuffer->maxCols, row.effectiveColumnCount);
   if (currentTableBuffer->totalCells > MAX_SIMPLE_TABLE_CELLS ||
       currentTableBuffer->maxCols > MAX_SIMPLE_TABLE_COLUMNS) {
     currentTableBuffer->unsupported = true;
   }
 
   currentTableCellIsHeader = false;
+  currentTableCellColSpan = 1;
   wordsExtractedInBlock = 0;
   nextWordContinues = false;
 }
@@ -269,6 +273,11 @@ void ChapterHtmlSlimParser::emitBufferedTableAsFragments(BufferedTable& table) {
     std::vector<FootnoteEntry> footnotes;
   };
 
+  struct PreparedSegment {
+    uint8_t columnCount = 0;
+    std::vector<PreparedRow> rows;
+  };
+
   if (!currentPage) {
     currentPage.reset(new Page());
     currentPageNextY = 0;
@@ -277,34 +286,33 @@ void ChapterHtmlSlimParser::emitBufferedTableAsFragments(BufferedTable& table) {
   const int horizontalInset = table.blockStyle.totalHorizontalInset();
   const uint16_t tableWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
-  const uint16_t baseColumnWidth = table.maxCols > 0 ? tableWidth / table.maxCols : 0;
-  const uint16_t innerColumnWidth =
-      (baseColumnWidth > TABLE_CELL_PADDING * 2) ? static_cast<uint16_t>(baseColumnWidth - TABLE_CELL_PADDING * 2) : 0;
-  if (table.maxCols == 0 || innerColumnWidth < 20) {
-    LOG_DBG("EHP", "Table layout fallback: width %u too small for %u columns", tableWidth, table.maxCols);
-    emitBufferedTableAsParagraphs(table);
-    return;
-  }
-
   const uint16_t lineHeight = renderer.getLineHeight(fontId) * lineCompression;
-  std::vector<PreparedRow> preparedRows;
-  preparedRows.reserve(table.rows.size());
+  std::vector<PreparedSegment> preparedSegments;
+  preparedSegments.reserve(table.rows.size());
 
-  for (auto& row : table.rows) {
+  auto prepareRow = [&](const BufferedTableRow& row, const uint8_t columnCount, PreparedSegment& segment) -> bool {
+    const uint16_t baseColumnWidth = columnCount > 0 ? tableWidth / columnCount : 0;
+    const uint16_t innerColumnWidth = (baseColumnWidth > TABLE_CELL_PADDING * 2)
+                                          ? static_cast<uint16_t>(baseColumnWidth - TABLE_CELL_PADDING * 2)
+                                          : 0;
+    if (columnCount == 0 || innerColumnWidth < 20) {
+      LOG_DBG("EHP", "Table layout fallback: width %u too small for %u columns", tableWidth, columnCount);
+      return false;
+    }
+
     PreparedRow prepared;
-    prepared.fragmentRow.cells.resize(table.maxCols);
+    prepared.fragmentRow.cells.resize(columnCount);
     prepared.fragmentRow.headerSeparator = row.hasHeaderCell && !row.hasDataCell;
 
     uint32_t rowHeight = static_cast<uint32_t>(lineHeight) + TABLE_CELL_PADDING * 2;
     if (rowHeight > viewportHeight) {
       LOG_DBG("EHP", "Table layout fallback: row height %lu exceeds viewport %u", static_cast<unsigned long>(rowHeight),
               viewportHeight);
-      emitBufferedTableAsParagraphs(table);
-      return;
+      return false;
     }
 
     for (size_t colIndex = 0; colIndex < row.cells.size(); colIndex++) {
-      auto& sourceCell = row.cells[colIndex];
+      const auto& sourceCell = row.cells[colIndex];
       auto& destCell = prepared.fragmentRow.cells[colIndex];
       destCell.isHeader = sourceCell.isHeader;
 
@@ -322,8 +330,7 @@ void ChapterHtmlSlimParser::emitBufferedTableAsFragments(BufferedTable& table) {
       if (destCell.lines.size() > TableFragmentCell::MAX_SERIALIZED_LINES) {
         LOG_DBG("EHP", "Table layout fallback: cell line count %u exceeds fragment max %u",
                 static_cast<uint32_t>(destCell.lines.size()), TableFragmentCell::MAX_SERIALIZED_LINES);
-        emitBufferedTableAsParagraphs(table);
-        return;
+        return false;
       }
 
       const uint32_t cellLineCount = std::max<size_t>(1, destCell.lines.size());
@@ -331,15 +338,40 @@ void ChapterHtmlSlimParser::emitBufferedTableAsFragments(BufferedTable& table) {
       if (cellHeight > viewportHeight) {
         LOG_DBG("EHP", "Table layout fallback: row height %lu exceeds viewport %u",
                 static_cast<unsigned long>(cellHeight), viewportHeight);
-        emitBufferedTableAsParagraphs(table);
-        return;
+        return false;
       }
 
       rowHeight = std::max<uint32_t>(rowHeight, cellHeight);
     }
 
     prepared.fragmentRow.height = static_cast<uint16_t>(rowHeight);
-    preparedRows.push_back(std::move(prepared));
+    segment.rows.push_back(std::move(prepared));
+    return true;
+  };
+
+  for (const auto& row : table.rows) {
+    const bool rowHasMergedCells = std::any_of(row.cells.begin(), row.cells.end(),
+                                               [](const BufferedTableCell& cell) { return cell.colSpan != 1; });
+    const bool isFullWidthSingleCellRow =
+        row.cells.size() == 1 && table.maxCols > 0 && row.cells[0].colSpan == table.maxCols;
+
+    if (rowHasMergedCells && !isFullWidthSingleCellRow) {
+      LOG_DBG("EHP", "Table layout fallback: unsupported colspan structure");
+      emitBufferedTableAsParagraphs(table);
+      return;
+    }
+
+    const uint8_t segmentColumnCount = isFullWidthSingleCellRow ? 1 : static_cast<uint8_t>(table.maxCols);
+    if (preparedSegments.empty() || preparedSegments.back().columnCount != segmentColumnCount) {
+      preparedSegments.push_back({});
+      preparedSegments.back().columnCount = segmentColumnCount;
+      preparedSegments.back().rows.reserve(table.rows.size());
+    }
+
+    if (!prepareRow(row, segmentColumnCount, preparedSegments.back())) {
+      emitBufferedTableAsParagraphs(table);
+      return;
+    }
   }
 
   if (table.blockStyle.marginTop > 0) {
@@ -348,59 +380,61 @@ void ChapterHtmlSlimParser::emitBufferedTableAsFragments(BufferedTable& table) {
   if (table.blockStyle.paddingTop > 0) {
     currentPageNextY += table.blockStyle.paddingTop;
   }
-
-  size_t nextRowIndex = 0;
-  while (nextRowIndex < preparedRows.size()) {
-    if (!currentPage) {
-      currentPage.reset(new Page());
-      currentPageNextY = 0;
-    }
-
-    std::vector<TableFragmentRow> fragmentRows;
-    std::vector<FootnoteEntry> fragmentFootnotes;
-    uint16_t fragmentHeight = 1;  // Bottom border.
-
-    while (nextRowIndex < preparedRows.size()) {
-      const uint16_t nextHeight = static_cast<uint16_t>(fragmentHeight + preparedRows[nextRowIndex].fragmentRow.height);
-      if (!fragmentRows.empty() && currentPageNextY + nextHeight > viewportHeight) {
-        break;
+  for (auto& segment : preparedSegments) {
+    size_t nextRowIndex = 0;
+    while (nextRowIndex < segment.rows.size()) {
+      if (!currentPage) {
+        currentPage.reset(new Page());
+        currentPageNextY = 0;
       }
-      if (fragmentRows.empty() && currentPageNextY + nextHeight > viewportHeight && !currentPage->elements.empty()) {
+
+      std::vector<TableFragmentRow> fragmentRows;
+      std::vector<FootnoteEntry> fragmentFootnotes;
+      uint16_t fragmentHeight = 1;  // Bottom border.
+
+      while (nextRowIndex < segment.rows.size()) {
+        const uint16_t nextHeight =
+            static_cast<uint16_t>(fragmentHeight + segment.rows[nextRowIndex].fragmentRow.height);
+        if (!fragmentRows.empty() && currentPageNextY + nextHeight > viewportHeight) {
+          break;
+        }
+        if (fragmentRows.empty() && currentPageNextY + nextHeight > viewportHeight && !currentPage->elements.empty()) {
+          completePageFn(std::move(currentPage), xpathParagraphIndex);
+          completedPageCount++;
+          currentPage.reset(new Page());
+          currentPageNextY = 0;
+          continue;
+        }
+
+        fragmentHeight = nextHeight;
+        fragmentRows.push_back(std::move(segment.rows[nextRowIndex].fragmentRow));
+        fragmentFootnotes.insert(fragmentFootnotes.end(), segment.rows[nextRowIndex].footnotes.begin(),
+                                 segment.rows[nextRowIndex].footnotes.end());
+        nextRowIndex++;
+      }
+
+      if (fragmentRows.empty()) {
+        fragmentHeight = static_cast<uint16_t>(1 + segment.rows[nextRowIndex].fragmentRow.height);
+        fragmentRows.push_back(std::move(segment.rows[nextRowIndex].fragmentRow));
+        fragmentFootnotes.insert(fragmentFootnotes.end(), segment.rows[nextRowIndex].footnotes.begin(),
+                                 segment.rows[nextRowIndex].footnotes.end());
+        nextRowIndex++;
+      }
+
+      currentPage->elements.push_back(
+          std::make_shared<PageTableFragment>(tableWidth, segment.columnCount, TABLE_CELL_PADDING, lineHeight,
+                                              std::move(fragmentRows), table.blockStyle.leftInset(), currentPageNextY));
+      for (const auto& footnote : fragmentFootnotes) {
+        currentPage->addFootnote(footnote.number, footnote.href);
+      }
+      currentPageNextY += fragmentHeight;
+
+      if (nextRowIndex < segment.rows.size()) {
         completePageFn(std::move(currentPage), xpathParagraphIndex);
         completedPageCount++;
         currentPage.reset(new Page());
         currentPageNextY = 0;
-        continue;
       }
-
-      fragmentHeight = nextHeight;
-      fragmentRows.push_back(std::move(preparedRows[nextRowIndex].fragmentRow));
-      fragmentFootnotes.insert(fragmentFootnotes.end(), preparedRows[nextRowIndex].footnotes.begin(),
-                               preparedRows[nextRowIndex].footnotes.end());
-      nextRowIndex++;
-    }
-
-    if (fragmentRows.empty()) {
-      fragmentHeight = static_cast<uint16_t>(1 + preparedRows[nextRowIndex].fragmentRow.height);
-      fragmentRows.push_back(std::move(preparedRows[nextRowIndex].fragmentRow));
-      fragmentFootnotes.insert(fragmentFootnotes.end(), preparedRows[nextRowIndex].footnotes.begin(),
-                               preparedRows[nextRowIndex].footnotes.end());
-      nextRowIndex++;
-    }
-
-    currentPage->elements.push_back(std::make_shared<PageTableFragment>(
-        tableWidth, static_cast<uint8_t>(table.maxCols), TABLE_CELL_PADDING, lineHeight, std::move(fragmentRows),
-        table.blockStyle.leftInset(), currentPageNextY));
-    for (const auto& footnote : fragmentFootnotes) {
-      currentPage->addFootnote(footnote.number, footnote.href);
-    }
-    currentPageNextY += fragmentHeight;
-
-    if (nextRowIndex < preparedRows.size()) {
-      completePageFn(std::move(currentPage), xpathParagraphIndex);
-      completedPageCount++;
-      currentPage.reset(new Page());
-      currentPageNextY = 0;
     }
   }
 
@@ -535,10 +569,22 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
     const char* colspan = getAttribute(atts, "colspan");
     const char* rowspan = getAttribute(atts, "rowspan");
-    if (self->currentTableBuffer &&
-        ((colspan && strcmp(colspan, "1") != 0) || (rowspan && strcmp(rowspan, "1") != 0))) {
+    uint8_t parsedColSpan = 1;
+    if (colspan && colspan[0] != '\0') {
+      char* endPtr = nullptr;
+      const long parsedValue = std::strtol(colspan, &endPtr, 10);
+      if (endPtr == colspan || *endPtr != '\0' || parsedValue <= 0 || parsedValue > UINT8_MAX) {
+        if (self->currentTableBuffer) {
+          self->currentTableBuffer->unsupported = true;
+        }
+      } else {
+        parsedColSpan = static_cast<uint8_t>(parsedValue);
+      }
+    }
+    if (self->currentTableBuffer && rowspan && strcmp(rowspan, "1") != 0) {
       self->currentTableBuffer->unsupported = true;
     }
+    self->currentTableCellColSpan = parsedColSpan;
 
     auto tableCellBlockStyle = BlockStyle();
     tableCellBlockStyle.textAlignDefined = true;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -83,12 +83,14 @@ class ChapterHtmlSlimParser {
     std::unique_ptr<ParsedText> text;
     std::vector<std::pair<int, FootnoteEntry>> footnotes;
     bool isHeader = false;
+    uint8_t colSpan = 1;
   };
 
   struct BufferedTableRow {
     std::vector<BufferedTableCell> cells;
     bool hasHeaderCell = false;
     bool hasDataCell = false;
+    uint16_t effectiveColumnCount = 0;
   };
 
   struct BufferedTable {
@@ -103,6 +105,7 @@ class ChapterHtmlSlimParser {
   int tableRowIndex = 0;
   int tableColIndex = 0;
   bool currentTableCellIsHeader = false;
+  uint8_t currentTableCellColSpan = 1;
   std::unique_ptr<BufferedTable> currentTableBuffer = nullptr;
   std::vector<CssAncestorEntry> ancestorStack_;
 


### PR DESCRIPTION
## Summary

- Allow simple EPUB tables with full-width note rows so a single `colspan` cell spanning the whole table no longer forces the entire table back to paragraph fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lyra Carousel theme.

* **Bug Fixes**
  * Fixed EPUB table rendering with proper column span handling.
  * Fixed crash when displaying page overlay with invalid cached EPUB data.
  * Fixed "Go to %" jump calculation serialization.
  * Fixed OTA update checks with firmware variant matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->