### PR TITLE
fix: render missing Unicode reader glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add real EPUB `<hr>` rendering so horizontal rules now display as visible separators instead of being ignored
 
 ### Fixed
+- Render missing Unicode block redactions, black-square ornaments, Greek category letters, and turned-comma punctuation in reader fonts
 - Serialize SD-card and display access on the shared SPI bus to prevent task-ownership crashes during state saves, sleep transitions, and other concurrent render/storage activity
 - Guard SPI bus lock acquisition so a failed recursive mutex take no longer marks the lock as held and triggers a mismatched release
 - Harden EPUB section-cache writes and promotion so truncated SD writes fail fast, temp caches are synced before rename, and invalid page-cache files are less likely to persist across reloads

--- a/lib/EpdFont/EpdFontData.h
+++ b/lib/EpdFont/EpdFontData.h
@@ -130,3 +130,100 @@ typedef struct {
   const EpdLigaturePair* ligaturePairs;  ///< Sorted ligature pair table (nullptr if none)
   uint32_t ligaturePairCount;            ///< Number of entries in ligaturePairs
 } EpdFontData;
+
+namespace syntheticGlyph {
+
+constexpr uint32_t FULL_BLOCK = 0x2588;
+constexpr uint32_t BLACK_SQUARE = 0x25A0;
+constexpr uint32_t GREEK_CAPITAL_GAMMA = 0x0393;
+constexpr uint32_t GREEK_SMALL_EPSILON = 0x03B5;
+constexpr uint32_t GREEK_SMALL_OMEGA = 0x03C9;
+constexpr uint32_t MODIFIER_LETTER_TURNED_COMMA = 0x02BB;
+constexpr uint32_t LEFT_SINGLE_QUOTATION_MARK = 0x2018;
+
+constexpr bool isSolid(uint32_t cp) { return cp == FULL_BLOCK || cp == BLACK_SQUARE; }
+constexpr bool isGreekFallback(uint32_t cp) {
+  return cp == GREEK_CAPITAL_GAMMA || cp == GREEK_SMALL_EPSILON || cp == GREEK_SMALL_OMEGA;
+}
+constexpr uint32_t aliasCodepoint(uint32_t cp) {
+  return cp == MODIFIER_LETTER_TURNED_COMMA ? LEFT_SINGLE_QUOTATION_MARK : cp;
+}
+
+inline uint16_t solidAdvanceX(const EpdFontData* data, const EpdGlyph* emGlyph) {
+  if (emGlyph && emGlyph->advanceX > 0) {
+    return emGlyph->advanceX;
+  }
+  int px = data && data->ascender > 0 ? (data->ascender * 3 + 3) / 4 : 8;
+  if (px < 1) px = 1;
+  return static_cast<uint16_t>(fp4::fromPixel(px));
+}
+
+inline int solidHeight(const EpdFontData* data, uint32_t cp) {
+  int ascender = data && data->ascender > 0 ? data->ascender : 8;
+  if (cp == BLACK_SQUARE) {
+    int height = (ascender * 2 + 2) / 3;
+    return height > 1 ? height : 1;
+  }
+  return ascender > 1 ? ascender : 1;
+}
+
+inline int solidWidth(uint32_t cp, uint16_t advanceX, int height) {
+  const int advancePx = fp4::toPixel(advanceX);
+  if (cp == BLACK_SQUARE) {
+    return height < advancePx ? height : advancePx;
+  }
+  return advancePx > 1 ? advancePx : 1;
+}
+
+inline int solidLeft(uint32_t cp, uint16_t advanceX, int width) {
+  if (cp != BLACK_SQUARE) return 0;
+  const int advancePx = fp4::toPixel(advanceX);
+  return advancePx > width ? (advancePx - width) / 2 : 0;
+}
+
+inline int solidTop(const EpdFontData* data, uint32_t cp, int height) {
+  const int ascender = data && data->ascender > 0 ? data->ascender : height;
+  if (cp != BLACK_SQUARE || ascender <= height) return height;
+  return height + (ascender - height) / 2;
+}
+
+inline uint16_t greekAdvanceX(const EpdFontData* data, const EpdGlyph* emGlyph, uint32_t cp) {
+  if (cp == GREEK_SMALL_OMEGA && emGlyph && emGlyph->advanceX > 0) {
+    return emGlyph->advanceX;
+  }
+  const int ascender = data && data->ascender > 0 ? data->ascender : 8;
+  int px = cp == GREEK_CAPITAL_GAMMA ? (ascender * 7 + 5) / 10 : (ascender * 3 + 3) / 4;
+  if (px < 1) px = 1;
+  return static_cast<uint16_t>(fp4::fromPixel(px));
+}
+
+inline int greekHeight(const EpdFontData* data, uint32_t cp) {
+  int ascender = data && data->ascender > 0 ? data->ascender : 8;
+  if (cp != GREEK_CAPITAL_GAMMA) {
+    ascender = (ascender * 3 + 3) / 4;
+  }
+  return ascender > 1 ? ascender : 1;
+}
+
+inline int greekWidth(uint32_t cp, uint16_t advanceX, int height) {
+  const int advancePx = fp4::toPixel(advanceX);
+  if (cp == GREEK_CAPITAL_GAMMA) {
+    const int width = height > 2 ? (height * 6 + 5) / 10 : height;
+    return width < advancePx ? width : advancePx;
+  }
+  return advancePx > 1 ? advancePx : 1;
+}
+
+inline int greekLeft(uint32_t cp, uint16_t advanceX, int width) {
+  const int advancePx = fp4::toPixel(advanceX);
+  if (cp == GREEK_CAPITAL_GAMMA) return 0;
+  return advancePx > width ? (advancePx - width) / 2 : 0;
+}
+
+inline int greekTop(const EpdFontData* data, uint32_t cp, int height) {
+  const int ascender = data && data->ascender > 0 ? data->ascender : height;
+  if (cp == GREEK_CAPITAL_GAMMA || ascender <= height) return height;
+  return height + (ascender - height) / 2;
+}
+
+}  // namespace syntheticGlyph

--- a/lib/EpdFont/EpdFontFamily.cpp
+++ b/lib/EpdFont/EpdFontFamily.cpp
@@ -43,6 +43,61 @@ void EpdFontFamily::getTextDimensions(const char* string, int* w, int* h, const 
 
     if (!isCombining) {
       cp = applyLigatures(cp, string, style);
+      cp = getFallbackCodepoint(cp, style);
+    }
+
+    const bool hasRealGlyph = findGlyphData(cp, style).glyph != nullptr;
+
+    if (!isCombining && !hasRealGlyph && syntheticGlyph::isSolid(cp)) {
+      const EpdFontData* data = getData(style);
+      const uint16_t advanceX = syntheticGlyph::solidAdvanceX(data, getGlyph('M', style));
+      const int glyphHeight = syntheticGlyph::solidHeight(data, cp);
+      const int glyphWidth = syntheticGlyph::solidWidth(cp, advanceX, glyphHeight);
+      const int glyphLeft = syntheticGlyph::solidLeft(cp, advanceX, glyphWidth);
+      const int glyphTop = syntheticGlyph::solidTop(data, cp, glyphHeight);
+
+      if (prevCp != 0) {
+        const auto kernFP = getKerning(prevCp, cp, style);
+        lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);
+      }
+
+      minX = std::min(minX, lastBaseX + glyphLeft);
+      maxX = std::max(maxX, lastBaseX + glyphLeft + glyphWidth);
+      minY = std::min(minY, glyphTop - glyphHeight);
+      maxY = std::max(maxY, glyphTop);
+
+      lastBaseLeft = glyphLeft;
+      lastBaseWidth = glyphWidth;
+      lastBaseTop = glyphTop;
+      prevAdvanceFP = advanceX;
+      prevCp = cp;
+      continue;
+    }
+
+    if (!isCombining && !hasRealGlyph && syntheticGlyph::isGreekFallback(cp)) {
+      const EpdFontData* data = getData(style);
+      const uint16_t advanceX = syntheticGlyph::greekAdvanceX(data, getGlyph('M', style), cp);
+      const int glyphHeight = syntheticGlyph::greekHeight(data, cp);
+      const int glyphWidth = syntheticGlyph::greekWidth(cp, advanceX, glyphHeight);
+      const int glyphLeft = syntheticGlyph::greekLeft(cp, advanceX, glyphWidth);
+      const int glyphTop = syntheticGlyph::greekTop(data, cp, glyphHeight);
+
+      if (prevCp != 0) {
+        const auto kernFP = getKerning(prevCp, cp, style);
+        lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);
+      }
+
+      minX = std::min(minX, lastBaseX + glyphLeft);
+      maxX = std::max(maxX, lastBaseX + glyphLeft + glyphWidth);
+      minY = std::min(minY, glyphTop - glyphHeight);
+      maxY = std::max(maxY, glyphTop);
+
+      lastBaseLeft = glyphLeft;
+      lastBaseWidth = glyphWidth;
+      lastBaseTop = glyphTop;
+      prevAdvanceFP = advanceX;
+      prevCp = cp;
+      continue;
     }
 
     const EpdGlyph* glyph = getGlyph(cp, style);
@@ -90,7 +145,7 @@ void EpdFontFamily::getTextDimensions(const char* string, int* w, int* h, const 
 
 const EpdFontData* EpdFontFamily::getData(const Style style) const { return getFont(style)->data; }
 
-EpdFontFamily::GlyphData EpdFontFamily::getGlyphData(const uint32_t cp, const Style style) const {
+EpdFontFamily::GlyphData EpdFontFamily::findGlyphData(const uint32_t cp, const Style style) const {
   const EpdFont* font = getFont(style);
   if (const EpdGlyph* glyph = font->findGlyph(cp)) {
     return {font->data, glyph};
@@ -102,6 +157,14 @@ EpdFontFamily::GlyphData EpdFontFamily::getGlyphData(const uint32_t cp, const St
     }
   }
 
+  return {nullptr, nullptr};
+}
+
+EpdFontFamily::GlyphData EpdFontFamily::getGlyphData(const uint32_t cp, const Style style) const {
+  if (const GlyphData glyphData = findGlyphData(cp, style); glyphData.glyph) {
+    return glyphData;
+  }
+
   if (cp != REPLACEMENT_GLYPH) {
     return getGlyphData(REPLACEMENT_GLYPH, style);
   }
@@ -110,6 +173,11 @@ EpdFontFamily::GlyphData EpdFontFamily::getGlyphData(const uint32_t cp, const St
 
 const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style) const {
   return getGlyphData(cp, style).glyph;
+}
+
+uint32_t EpdFontFamily::getFallbackCodepoint(const uint32_t cp, const Style style) const {
+  if (findGlyphData(cp, style).glyph) return cp;
+  return syntheticGlyph::aliasCodepoint(cp);
 }
 
 int8_t EpdFontFamily::getKerning(const uint32_t leftCp, const uint32_t rightCp, const Style style) const {

--- a/lib/EpdFont/EpdFontFamily.h
+++ b/lib/EpdFont/EpdFontFamily.h
@@ -15,8 +15,10 @@ class EpdFontFamily {
   ~EpdFontFamily() = default;
   void getTextDimensions(const char* string, int* w, int* h, Style style = REGULAR) const;
   const EpdFontData* getData(Style style = REGULAR) const;
+  GlyphData findGlyphData(uint32_t cp, Style style = REGULAR) const;
   GlyphData getGlyphData(uint32_t cp, Style style = REGULAR) const;
   const EpdGlyph* getGlyph(uint32_t cp, Style style = REGULAR) const;
+  uint32_t getFallbackCodepoint(uint32_t cp, Style style = REGULAR) const;
   int8_t getKerning(uint32_t leftCp, uint32_t rightCp, Style style = REGULAR) const;
   uint32_t applyLigatures(uint32_t cp, const char*& text, Style style = REGULAR) const;
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -74,6 +74,115 @@ static inline void rotateCoordinates(const GfxRenderer::Orientation orientation,
 
 enum class TextRotation { None, Rotated90CW };
 
+struct SyntheticSolidGlyphMetrics {
+  uint16_t advanceX;
+  int ascender;
+  int left;
+  int top;
+  int width;
+  int height;
+};
+
+static SyntheticSolidGlyphMetrics getSyntheticSolidGlyphMetrics(const EpdFontFamily& font,
+                                                                const EpdFontFamily::Style style, const uint32_t cp) {
+  const EpdFontData* data = font.getData(style);
+  const uint16_t advanceX = syntheticGlyph::solidAdvanceX(data, font.getGlyph('M', style));
+  const int height = syntheticGlyph::solidHeight(data, cp);
+  const int width = syntheticGlyph::solidWidth(cp, advanceX, height);
+  const int ascender = data && data->ascender > 0 ? data->ascender : height;
+  return {
+      advanceX, ascender, syntheticGlyph::solidLeft(cp, advanceX, width), syntheticGlyph::solidTop(data, cp, height),
+      width,    height};
+}
+
+static SyntheticSolidGlyphMetrics getSyntheticGreekGlyphMetrics(const EpdFontFamily& font,
+                                                                const EpdFontFamily::Style style, const uint32_t cp) {
+  const EpdFontData* data = font.getData(style);
+  const uint16_t advanceX = syntheticGlyph::greekAdvanceX(data, font.getGlyph('M', style), cp);
+  const int height = syntheticGlyph::greekHeight(data, cp);
+  const int width = syntheticGlyph::greekWidth(cp, advanceX, height);
+  const int ascender = data && data->ascender > 0 ? data->ascender : height;
+  return {
+      advanceX, ascender, syntheticGlyph::greekLeft(cp, advanceX, width), syntheticGlyph::greekTop(data, cp, height),
+      width,    height};
+}
+
+static void fillSyntheticSolidGlyph(const GfxRenderer& renderer, const SyntheticSolidGlyphMetrics& metrics,
+                                    const int cursorX, const int baselineY, const bool pixelState) {
+  renderer.fillRect(cursorX + metrics.left, baselineY - metrics.top, metrics.width, metrics.height, pixelState);
+}
+
+static void fillSyntheticSolidGlyphRotated90CW(const GfxRenderer& renderer, const SyntheticSolidGlyphMetrics& metrics,
+                                               const int cursorX, const int cursorY, const bool pixelState) {
+  renderer.fillRect(cursorX + metrics.ascender - metrics.top, cursorY - metrics.left - metrics.width + 1,
+                    metrics.height, metrics.width, pixelState);
+}
+
+static int syntheticStroke(const SyntheticSolidGlyphMetrics& metrics) {
+  const int minDim = metrics.width < metrics.height ? metrics.width : metrics.height;
+  return minDim >= 14 ? 2 : 1;
+}
+
+static bool epsilonTemplatePixel(const int srcX, const int srcY) {
+  static constexpr uint8_t EPSILON_7X7[] = {
+      0b0111110, 0b1100000, 0b1000000, 0b1111100, 0b1000000, 0b1100000, 0b0111110,
+  };
+  return (EPSILON_7X7[srcY] & (1 << (6 - srcX))) != 0;
+}
+
+static void drawSyntheticGreekGlyph(const GfxRenderer& renderer, const SyntheticSolidGlyphMetrics& metrics,
+                                    const uint32_t cp, const int cursorX, const int baselineY, const bool pixelState) {
+  const int x = cursorX + metrics.left;
+  const int y = baselineY - metrics.top;
+  const int w = metrics.width;
+  const int h = metrics.height;
+  const int s = syntheticStroke(metrics);
+  if (w <= 0 || h <= 0) return;
+
+  if (cp == syntheticGlyph::GREEK_CAPITAL_GAMMA) {
+    renderer.fillRect(x, y, s, h, pixelState);
+    renderer.fillRect(x, y, w, s, pixelState);
+  } else if (cp == syntheticGlyph::GREEK_SMALL_EPSILON) {
+    for (int gy = 0; gy < h; gy++) {
+      const int srcY = gy * 7 / h;
+      for (int gx = 0; gx < w; gx++) {
+        if (epsilonTemplatePixel(gx * 7 / w, srcY)) renderer.drawPixel(x + gx, y + gy, pixelState);
+      }
+    }
+  } else if (cp == syntheticGlyph::GREEK_SMALL_OMEGA) {
+    const int mid = w / 2;
+    renderer.fillRect(x, y + s, s, h - 2 * s, pixelState);
+    renderer.fillRect(x + w - s, y + s, s, h - 2 * s, pixelState);
+    renderer.fillRect(x + s, y + h - s, mid - s, s, pixelState);
+    renderer.fillRect(x + mid, y + h - s, w - mid - s, s, pixelState);
+    renderer.fillRect(x + mid - s / 2, y + h / 2, s, h / 2, pixelState);
+  }
+}
+
+static void drawSyntheticGreekGlyphRotated90CW(const GfxRenderer& renderer, const SyntheticSolidGlyphMetrics& metrics,
+                                               const uint32_t cp, const int cursorX, const int cursorY,
+                                               const bool pixelState) {
+  const int baseX = cursorX + metrics.ascender - metrics.top;
+  const int baseY = cursorY - metrics.left;
+  const int s = syntheticStroke(metrics);
+  for (int gy = 0; gy < metrics.height; gy++) {
+    for (int gx = 0; gx < metrics.width; gx++) {
+      bool draw = false;
+      if (cp == syntheticGlyph::GREEK_CAPITAL_GAMMA) {
+        draw = gx < s || gy < s;
+      } else if (cp == syntheticGlyph::GREEK_SMALL_EPSILON) {
+        draw = epsilonTemplatePixel(gx * 7 / metrics.width, gy * 7 / metrics.height);
+      } else if (cp == syntheticGlyph::GREEK_SMALL_OMEGA) {
+        draw = (gx < s && gy >= s && gy < metrics.height - s) ||
+               (gx >= metrics.width - s && gy >= s && gy < metrics.height - s) ||
+               (gy >= metrics.height - s && gx >= s && gx < metrics.width - s) ||
+               (gx >= metrics.width / 2 - s / 2 && gx < metrics.width / 2 - s / 2 + s && gy >= metrics.height / 2);
+      }
+      if (draw) renderer.drawPixel(baseX + gy, baseY - gx, pixelState);
+    }
+  }
+}
+
 // Shared glyph rendering logic for normal and rotated text.
 // Coordinate mapping and cursor advance direction are selected at compile time via the template parameter.
 template <TextRotation rotation>
@@ -253,6 +362,8 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     }
 
     cp = font.applyLigatures(cp, text, style);
+    cp = font.getFallbackCodepoint(cp, style);
+    const bool hasRealGlyph = font.findGlyphData(cp, style).glyph != nullptr;
 
     // Differential rounding: snap (previous advance + current kern) as one unit so
     // identical character pairs always produce the same pixel step regardless of
@@ -260,6 +371,28 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
       lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isSolid(cp)) {
+      const auto metrics = getSyntheticSolidGlyphMetrics(font, style, cp);
+      fillSyntheticSolidGlyph(*this, metrics, lastBaseX, yPos, black);
+      lastBaseLeft = metrics.left;
+      lastBaseWidth = metrics.width;
+      lastBaseTop = metrics.top;
+      prevAdvanceFP = metrics.advanceX;
+      prevCp = cp;
+      continue;
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isGreekFallback(cp)) {
+      const auto metrics = getSyntheticGreekGlyphMetrics(font, style, cp);
+      drawSyntheticGreekGlyph(*this, metrics, cp, lastBaseX, yPos, black);
+      lastBaseLeft = metrics.left;
+      lastBaseWidth = metrics.width;
+      lastBaseTop = metrics.top;
+      prevAdvanceFP = metrics.advanceX;
+      prevCp = cp;
+      continue;
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);
@@ -1107,12 +1240,26 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
       continue;
     }
     cp = font.applyLigatures(cp, text, style);
+    cp = font.getFallbackCodepoint(cp, style);
+    const bool hasRealGlyph = font.findGlyphData(cp, style).glyph != nullptr;
 
     // Differential rounding: snap (previous advance + current kern) together,
     // matching drawText so measurement and rendering agree exactly.
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
       widthPx += fp4::toPixel(prevAdvanceFP + kernFP);         // snap 12.4 fixed-point to nearest pixel
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isSolid(cp)) {
+      prevAdvanceFP = getSyntheticSolidGlyphMetrics(font, style, cp).advanceX;
+      prevCp = cp;
+      continue;
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isGreekFallback(cp)) {
+      prevAdvanceFP = getSyntheticGreekGlyphMetrics(font, style, cp).advanceX;
+      prevCp = cp;
+      continue;
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);
@@ -1188,12 +1335,36 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
     }
 
     cp = font.applyLigatures(cp, text, style);
+    cp = font.getFallbackCodepoint(cp, style);
+    const bool hasRealGlyph = font.findGlyphData(cp, style).glyph != nullptr;
 
     // Differential rounding: snap (previous advance + current kern) as one unit,
     // subtracting for the rotated coordinate direction.
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
       lastBaseY -= fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isSolid(cp)) {
+      const auto metrics = getSyntheticSolidGlyphMetrics(font, style, cp);
+      fillSyntheticSolidGlyphRotated90CW(*this, metrics, x, lastBaseY, black);
+      lastBaseLeft = metrics.left;
+      lastBaseWidth = metrics.width;
+      lastBaseTop = metrics.top;
+      prevAdvanceFP = metrics.advanceX;
+      prevCp = cp;
+      continue;
+    }
+
+    if (!hasRealGlyph && syntheticGlyph::isGreekFallback(cp)) {
+      const auto metrics = getSyntheticGreekGlyphMetrics(font, style, cp);
+      drawSyntheticGreekGlyphRotated90CW(*this, metrics, cp, x, lastBaseY, black);
+      lastBaseLeft = metrics.left;
+      lastBaseWidth = metrics.width;
+      lastBaseTop = metrics.top;
+      prevAdvanceFP = metrics.advanceX;
+      prevCp = cp;
+      continue;
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);


### PR DESCRIPTION
## Summary

- Fixes rendering problems in *There Is No Antimemetics Division* on the Xteink X4/CrossInk tiny firmware, where black-bar redactions could collapse into whitespace and some symbolic text rendered as replacement diamonds.
- Adds small synthetic renderer fallbacks for the missing Unicode glyphs that motivated that failure but can also appear in other EPUB text: full block redactions, black square ornaments, Greek Γ/ε/ω, and U+02BB turned-comma punctuation via an existing curly-quote alias.
- Keeps the change in renderer/measurement code rather than regenerating or expanding font assets, so it avoids adding large glyph tables and keeps RAM usage unchanged.
- The black redaction bars render as solid bars now. The non-black-bar fallbacks, especially the Greek glyphs, are intentionally approximate and may not look as good as real font glyphs; this seems like a reasonable compromise between somewhat proper rendering and not increasing firmware image size with broader font coverage.
- Adds a changelog entry for the reader rendering fix.

## Why

The primary motivator was *There Is No Antimemetics Division*, which includes black-bar redactions and symbolic/category text that exposed missing glyph coverage in the tiny firmware fonts. On device, those missing glyphs either collapsed into confusing whitespace or displayed replacement diamonds. This was especially confusing for black-bar redactions because the redacted span looked like a normal gap in the sentence.

I scanned the visible text in that EPUB against the tiny firmware font headers and found the unsupported visible text codepoints were U+02BB, U+0393, U+03B5, U+03C9, U+2588, and U+25A0. This patch handles that set generically rather than adding a book-specific workaround.

## Validation

- Ran ./bin/clang-format-fix using clang-format 22.1.4.
- Ran pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high; passed for tiny, xlarge, and no_emoji.
- Ran pio run; passed for tiny, xlarge, and no_emoji.
- Compared tiny build size before/after: RAM stayed unchanged for tiny, while flash increased by about 2.1 KB.
- Manually flashed the tiny firmware and checked *There Is No Antimemetics Division* pages on Xteink X4/CrossInk: page 6/9 redaction bars rendered correctly; the Greek/turned punctuation page improved but remains visually approximate.
- Cleared the CrossInk EPUB cache before retesting cached layout/rendering behavior.

## Disclosure

This patch was written with Codex assistance; in plain terms, it was vibecoded and then locally formatted, built, and checked before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synthetic glyph rendering with improved Unicode character fallback options.
  * Enhanced EPUB document rendering for horizontal rule elements.

* **Bug Fixes**
  * Fixed rendering of missing Unicode-related character artifacts in reader fonts.
  * Improved system stability with safer cache and memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->