### PR TITLE
Toggle hidden files from file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add real EPUB `<hr>` rendering so horizontal rules now display as visible separators instead of being ignored
+- Add a file-browser Home long-press shortcut for toggling hidden files
 
 ### Fixed
 - Render missing Unicode block redactions, black-square ornaments, Greek category letters, and turned-comma punctuation in reader fonts

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -43,6 +43,22 @@ std::string normalizeDirectoryPath(std::string path) {
   return path;
 }
 
+bool containsHiddenPathSegment(const std::string& path) {
+  if (path.empty()) return false;
+  size_t segmentStart = (path.front() == '/') ? 1 : 0;
+  while (segmentStart < path.length()) {
+    const size_t segmentEnd = path.find('/', segmentStart);
+    if (segmentStart < path.length() && path[segmentStart] == '.') {
+      return true;
+    }
+    if (segmentEnd == std::string::npos) {
+      break;
+    }
+    segmentStart = segmentEnd + 1;
+  }
+  return false;
+}
+
 void collectMetadataPathsRecursively(const std::string& dirPath, std::vector<std::string>& paths) {
   auto dir = Storage.open(dirPath.c_str());
   if (!dir || !dir.isDirectory()) {
@@ -298,15 +314,33 @@ void FileBrowserActivity::showFileActionMenu(const std::string& entry, bool igno
       });
 }
 
-void FileBrowserActivity::loop() {
-  // Long press BACK (1s+) goes to root folder (Books mode only).
-  // In firmware-pick mode we keep navigation simple: short Back = up dir / cancel.
-  if (mode == Mode::Books && mappedInput.isPressed(MappedInputManager::Button::Back) &&
-      mappedInput.getHeldTime() >= GO_HOME_MS && basepath != "/" && !lockLongPressBack) {
+void FileBrowserActivity::toggleHiddenFiles() {
+  const std::string currentEntry =
+      (!files.empty() && selectorIndex < files.size()) ? files[selectorIndex] : std::string();
+  SETTINGS.showHiddenFiles = SETTINGS.showHiddenFiles ? 0 : 1;
+  if (!SETTINGS.saveToFile()) {
+    LOG_ERR("FileBrowser", "Failed to save showHiddenFiles=%u", SETTINGS.showHiddenFiles);
+  }
+
+  if (!SETTINGS.showHiddenFiles && containsHiddenPathSegment(basepath)) {
     basepath = "/";
-    loadFiles();
-    selectorIndex = 0;
-    requestUpdate();
+  }
+
+  loadFiles();
+  selectorIndex = currentEntry.empty() ? 0 : findEntry(currentEntry);
+  if (!files.empty() && selectorIndex >= files.size()) {
+    selectorIndex = files.size() - 1;
+  }
+  requestUpdate();
+}
+
+void FileBrowserActivity::loop() {
+  // Long press BACK/HOME (1s+) toggles hidden files (Books mode only).
+  // In firmware-pick mode we keep navigation simple: short Back = up dir / cancel.
+  if (mode == Mode::Books && !longPressBackHandled && mappedInput.isPressed(MappedInputManager::Button::Back) &&
+      mappedInput.getHeldTime() >= GO_HOME_MS && !lockLongPressBack) {
+    longPressBackHandled = true;
+    toggleHiddenFiles();
     return;
   }
 
@@ -378,6 +412,10 @@ void FileBrowserActivity::loop() {
   }
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+    if (longPressBackHandled) {
+      longPressBackHandled = false;
+      return;
+    }
     // Short press: go up one directory, or go home if at root
     if (mappedInput.getHeldTime() < GO_HOME_MS) {
       if (basepath != "/") {

--- a/src/activities/home/FileBrowserActivity.h
+++ b/src/activities/home/FileBrowserActivity.h
@@ -28,6 +28,7 @@ class FileBrowserActivity final : public Activity {
   size_t selectorIndex = 0;
 
   bool lockLongPressBack = false;
+  bool longPressBackHandled = false;
   bool longPressConfirmHandled = false;
   // True when this activity was entered while Confirm was already held; we must swallow the next
   // release so we don't immediately auto-open the first entry.
@@ -41,6 +42,7 @@ class FileBrowserActivity final : public Activity {
 
   // Data loading
   void loadFiles();
+  void toggleHiddenFiles();
   size_t findEntry(const std::string& name) const;
 
  public:

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -7,8 +7,17 @@
 #include <Logging.h>
 #include <esp_task_wdt.h>
 
+#include <algorithm>
+#include <cstring>
+
 namespace {
 constexpr const char* HIDDEN_ITEMS[] = {"System Volume Information", "XTCache"};
+constexpr size_t HIDDEN_ITEM_COUNT = sizeof(HIDDEN_ITEMS) / sizeof(HIDDEN_ITEMS[0]);
+
+bool isHiddenItem(const char* name) {
+  return std::any_of(HIDDEN_ITEMS, HIDDEN_ITEMS + HIDDEN_ITEM_COUNT,
+                     [name](const auto* item) { return strcmp(name, item) == 0; });
+}
 
 // RFC 1123 date format helper: "Sun, 06 Nov 1994 08:49:37 GMT"
 // ESP32 doesn't have real-time clock set by default, so we use a fixed epoch date
@@ -227,15 +236,7 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
       file.getName(name, sizeof(name));
 
       // Skip hidden/protected items
-      bool shouldHide = (name[0] == '.');
-      if (!shouldHide) {
-        for (const auto* item : HIDDEN_ITEMS) {
-          if (strcmp(name, item) == 0) {
-            shouldHide = true;
-            break;
-          }
-        }
-      }
+      const bool shouldHide = (name[0] == '.') || isHiddenItem(name);
 
       if (!shouldHide) {
         String childPath = path;
@@ -773,9 +774,7 @@ bool WebDAVHandler::isProtectedPath(const String& path) const {
 
     if (segment.startsWith(".")) return true;
 
-    for (const auto* item : HIDDEN_ITEMS) {
-      if (segment.equals(item)) return true;
-    }
+    if (isHiddenItem(segment.c_str())) return true;
 
     start = end + 1;
   }


### PR DESCRIPTION
## Summary
- Add a file-browser Home/Back long-press shortcut that toggles `showHiddenFiles` and reloads the current directory.
- Swallow the release after the long press so it does not also navigate up or home.
- Return to `/` when hiding files from inside a hidden folder, so hidden paths do not remain visible.
- Add an Unreleased changelog entry.

## Validation
- `pio run -e simulator`
- `pio run -e tiny`
- `git diff --check`

## Hardware verification
- In Browse Files, long-press the mapped Home key for about one second and confirm dotfiles/dotfolders appear.
- Long-press it again and confirm dotfiles/dotfolders disappear without also navigating up or home.
- Short-press Home/Back to confirm normal up-folder/home navigation still works.