### PR TITLE
fix(home): fill XTC recent grid covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Harden EPUB section and page-cache reads/writes so truncated SD writes, invalid serialized strings, and bad temp-cache promotion fail safely
 - Prevent concurrent render/storage crashes by serializing `GfxRenderer` scratch-buffer access, shared SPI bus access, and failed SPI lock cleanup
 - Make reader prewarm lighter by skipping image decoding, keeping mixed-style font glyphs cached together, and avoiding section rebuilds for render-quality-only option changes
+- Make XTC covers fill the Recent Books grid cover slots instead of appearing letterboxed when the first page has a different aspect ratio
 - Keep the Recent Books grid from saving grid-sized cover thumbnails as reusable cover paths so Lyra Carousel does not render tiny covers
 - Avoid building the Lyra Carousel SD snapshot when RAM has already fallen back to a reduced frame cache
 

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -13,6 +13,21 @@
 
 #include <algorithm>
 
+namespace {
+bool thumbnailHasDimensions(const std::string& path, const uint16_t width, const uint16_t height) {
+  FsFile file;
+  if (!Storage.openFileForRead("XTC", path, file)) {
+    return false;
+  }
+
+  Bitmap bitmap(file);
+  const bool matches =
+      bitmap.parseHeaders() == BmpReaderError::Ok && bitmap.getWidth() == width && bitmap.getHeight() == height;
+  file.close();
+  return matches;
+}
+}  // namespace
+
 bool Xtc::load() {
   LOG_DBG("XTC", "Loading XTC: %s", filepath.c_str());
 
@@ -296,7 +311,12 @@ bool Xtc::generateThumbBmp(uint16_t width, uint16_t height) const {
     return false;
   }
   const std::string thumbPath = getThumbBmpPath(width, height);
-  if (Storage.exists(thumbPath.c_str())) return true;
+  const bool thumbExists = Storage.exists(thumbPath.c_str());
+  if (thumbExists) {
+    if (thumbnailHasDimensions(thumbPath, width, height)) {
+      return true;
+    }
+  }
 
   if (!loaded || !parser) {
     LOG_ERR("XTC", "Cannot generate thumb BMP, file not loaded");
@@ -314,50 +334,23 @@ bool Xtc::generateThumbBmp(uint16_t width, uint16_t height) const {
     LOG_DBG("XTC", "Failed to get first page info");
     return false;
   }
+  if (pageInfo.width == 0 || pageInfo.height == 0) {
+    LOG_ERR("XTC", "Cannot generate thumb BMP with invalid page dimensions: %ux%u", pageInfo.width, pageInfo.height);
+    return false;
+  }
+  if (thumbExists) {
+    Storage.remove(thumbPath.c_str());
+  }
 
   const uint8_t bitDepth = parser->getBitDepth();
   const uint16_t THUMB_TARGET_WIDTH = width;
   const uint16_t THUMB_TARGET_HEIGHT = height;
 
-  float scaleX = static_cast<float>(THUMB_TARGET_WIDTH) / pageInfo.width;
-  float scaleY = static_cast<float>(THUMB_TARGET_HEIGHT) / pageInfo.height;
-  float scale = std::min(scaleX, scaleY);
-
-  if (scale >= 1.0f) {
-    if (generateCoverBmp()) {
-      FsFile src, dst;
-      if (Storage.openFileForRead("XTC", getCoverBmpPath(), src)) {
-        if (Storage.openFileForWrite("XTC", thumbPath, dst)) {
-          bool copyOk = true;
-          uint8_t buffer[512];
-          while (src.available()) {
-            size_t bytesRead = src.read(buffer, sizeof(buffer));
-            if (bytesRead == 0) {
-              copyOk = false;
-              break;
-            }
-            const size_t bytesWritten = dst.write(buffer, bytesRead);
-            if (bytesWritten != bytesRead) {
-              copyOk = false;
-              break;
-            }
-          }
-          dst.close();
-          if (!copyOk) {
-            src.close();
-            Storage.remove(thumbPath.c_str());
-            return false;
-          }
-        }
-        src.close();
-      }
-      return Storage.exists(thumbPath.c_str());
-    }
-    return false;
-  }
-
-  uint16_t thumbWidth = static_cast<uint16_t>(pageInfo.width * scale);
-  uint16_t thumbHeight = static_cast<uint16_t>(pageInfo.height * scale);
+  const float scaleX = static_cast<float>(THUMB_TARGET_WIDTH) / pageInfo.width;
+  const float scaleY = static_cast<float>(THUMB_TARGET_HEIGHT) / pageInfo.height;
+  const float scale = std::max(scaleX, scaleY);
+  const uint16_t thumbWidth = THUMB_TARGET_WIDTH;
+  const uint16_t thumbHeight = THUMB_TARGET_HEIGHT;
 
   size_t bitmapSize;
   if (bitDepth == 2) {
@@ -397,7 +390,15 @@ bool Xtc::generateThumbBmp(uint16_t width, uint16_t height) const {
     return false;
   }
 
-  uint32_t scaleInv_fp = static_cast<uint32_t>(65536.0f / scale);
+  const uint32_t scaleInv_fp = static_cast<uint32_t>(65536.0f / scale);
+  const uint64_t srcWidth_fp = static_cast<uint64_t>(pageInfo.width) << 16;
+  const uint64_t srcHeight_fp = static_cast<uint64_t>(pageInfo.height) << 16;
+  const uint64_t visibleWidth_fp = static_cast<uint64_t>(thumbWidth) * scaleInv_fp;
+  const uint64_t visibleHeight_fp = static_cast<uint64_t>(thumbHeight) * scaleInv_fp;
+  const uint32_t cropX_fp =
+      static_cast<uint32_t>(srcWidth_fp > visibleWidth_fp ? (srcWidth_fp - visibleWidth_fp) / 2 : 0);
+  const uint32_t cropY_fp =
+      static_cast<uint32_t>(srcHeight_fp > visibleHeight_fp ? (srcHeight_fp - visibleHeight_fp) / 2 : 0);
   const size_t planeSize = (bitDepth == 2) ? ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) : 0;
   const uint8_t* plane1 = (bitDepth == 2) ? pageBuffer : nullptr;
   const uint8_t* plane2 = (bitDepth == 2) ? pageBuffer + planeSize : nullptr;
@@ -406,16 +407,16 @@ bool Xtc::generateThumbBmp(uint16_t width, uint16_t height) const {
 
   for (uint16_t dstY = 0; dstY < thumbHeight; dstY++) {
     memset(rowBuffer, 0xFF, rowSize);
-    uint32_t srcYStart = (static_cast<uint32_t>(dstY) * scaleInv_fp) >> 16;
-    uint32_t srcYEnd = (static_cast<uint32_t>(dstY + 1) * scaleInv_fp) >> 16;
+    uint32_t srcYStart = (cropY_fp + static_cast<uint32_t>(dstY) * scaleInv_fp) >> 16;
+    uint32_t srcYEnd = (cropY_fp + static_cast<uint32_t>(dstY + 1) * scaleInv_fp) >> 16;
     if (srcYStart >= pageInfo.height) srcYStart = pageInfo.height - 1;
     if (srcYEnd > pageInfo.height) srcYEnd = pageInfo.height;
     if (srcYEnd <= srcYStart) srcYEnd = srcYStart + 1;
     if (srcYEnd > pageInfo.height) srcYEnd = pageInfo.height;
 
     for (uint16_t dstX = 0; dstX < thumbWidth; dstX++) {
-      uint32_t srcXStart = (static_cast<uint32_t>(dstX) * scaleInv_fp) >> 16;
-      uint32_t srcXEnd = (static_cast<uint32_t>(dstX + 1) * scaleInv_fp) >> 16;
+      uint32_t srcXStart = (cropX_fp + static_cast<uint32_t>(dstX) * scaleInv_fp) >> 16;
+      uint32_t srcXEnd = (cropX_fp + static_cast<uint32_t>(dstX + 1) * scaleInv_fp) >> 16;
       if (srcXStart >= pageInfo.width) srcXStart = pageInfo.width - 1;
       if (srcXEnd > pageInfo.width) srcXEnd = pageInfo.width;
       if (srcXEnd <= srcXStart) srcXEnd = srcXStart + 1;

--- a/lib/Xtc/Xtc.h
+++ b/lib/Xtc/Xtc.h
@@ -94,11 +94,11 @@ class Xtc {
    */
   bool generateThumbBmp(uint16_t height) const;
   /**
-   * Generates a thumbnail in cache that fits within the requested bounding box.
-   * @param width Target bounding width in pixels.
-   * @param height Target bounding height in pixels.
+   * Generates a thumbnail in cache that fills the requested cover slot, cropping from center when aspect ratios differ.
+   * @param width Target output width in pixels.
+   * @param height Target output height in pixels.
    * @return true when the cached thumbnail exists or was written successfully; false on load/write/decode failure.
-   * @note Preferred overload for exact cache-key control. Existing files are reused.
+   * @note Preferred overload for exact cache-key control. Existing files are reused when dimensions match.
    */
   bool generateThumbBmp(uint16_t width, uint16_t height) const;
 

--- a/src/activities/home/RecentBooksGridActivity.cpp
+++ b/src/activities/home/RecentBooksGridActivity.cpp
@@ -130,6 +130,26 @@ bool hasThumbnailPlaceholder(const std::string& coverBmpPath) {
   return coverBmpPath.find("[WIDTH]") != std::string::npos || coverBmpPath.find("[HEIGHT]") != std::string::npos;
 }
 
+bool needsCoverThumbGeneration(const RecentBook& book, const std::string& thumbPath) {
+  if (thumbPath.empty() || !Storage.exists(thumbPath.c_str())) {
+    return true;
+  }
+  if (!FsHelpers::hasXtcExtension(book.path)) {
+    return false;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("RBGA", thumbPath, file)) {
+    return true;
+  }
+  Bitmap bitmap(file);
+  const bool hasExpectedSize = bitmap.parseHeaders() == BmpReaderError::Ok &&
+                               bitmap.getWidth() == RecentBooksGridActivity::COVER_WIDTH &&
+                               bitmap.getHeight() == RecentBooksGridActivity::COVER_HEIGHT;
+  file.close();
+  return !hasExpectedSize;
+}
+
 void calculateCoverFillCrop(const Bitmap& bitmap, float& cropX, float& cropY) {
   cropX = 0.0f;
   cropY = 0.0f;
@@ -206,7 +226,7 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
       break;
     }
     const std::string thumbPath = UITheme::getCoverThumbPath(book.coverBmpPath, COVER_WIDTH, COVER_HEIGHT);
-    if (!Storage.exists(thumbPath.c_str())) {
+    if (needsCoverThumbGeneration(book, thumbPath)) {
       needsGeneration = true;
       break;
     }
@@ -225,7 +245,7 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
     RecentBook& book = recentBooks[i].book;
     const std::string coverPath =
         book.coverBmpPath.empty() ? "" : UITheme::getCoverThumbPath(book.coverBmpPath, COVER_WIDTH, COVER_HEIGHT);
-    if (coverPath.empty() || !Storage.exists(coverPath.c_str())) {
+    if (needsCoverThumbGeneration(book, coverPath)) {
       if (FsHelpers::hasEpubExtension(book.path)) {
         Epub epub(book.path, "/.crosspoint");
         if (epub.load(false, true)) {


### PR DESCRIPTION
## Summary
- make XTC thumbnail generation write exact cover-slot dimensions for requested thumbnails
- center-crop XTC first-page thumbnails when aspect ratios differ, matching the Recent Books grid EPUB behavior
- make the Recent Books grid treat existing wrong-sized XTC thumbs as stale so old `thumb_123x180.bmp` files regenerate
- add a changelog entry for the Recent Books grid cover fix

## Root cause
The Recent Books grid asks for exact `COVER_WIDTH x COVER_HEIGHT` thumbnails, but XTC still treated that request as a fit-inside bounding box. For landscape first pages, it wrote a shorter BMP under a `thumb_123x180.bmp` cache filename, so the grid rendered a letterboxed cover and would keep reusing the stale file because the path existed.

## Validation
- `./bin/clang-format-fix`
- `git diff --check`
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`
- `pio run -e tiny -j1`