### PR TITLE
fix: validate saved credential payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Fixed the in-reader Customise Status Bar screen in landscape so the list no longer extends under the button labels.
 - Fixed manual WiFi connections from Settings returning immediately to the settings list after a saved-password or open-network connection succeeded, so the connected status and IP address are shown first.
+- Fixed copied or corrupted saved password files being treated as valid credentials by validating device-specific password data before using it.
 - Fixed missing Vietnamese labels for the sleep timeout resume settings.
 - Fixed File Browser and Lyra Carousel icon alignment issues in icon-based themes.
 - Reduced grid-like and over-zoomed artifacts on Lyra Carousel and Minimal theme's EPUB cover thumbnails by cropping normal covers before dithering while containing unusual cover ratios.

--- a/docs/webserver.md
+++ b/docs/webserver.md
@@ -52,7 +52,7 @@ After selecting **Join Network**, CrossInk scans for available WiFi networks.
 3. Enter the password if prompted.
 4. Save credentials if you want CrossInk to reconnect automatically later.
 
-Saved WiFi passwords are stored on the device SD card. Use this only on networks you trust.
+Saved WiFi passwords are stored on the device SD card with device-specific obfuscation. They are validated when read, so credentials copied from another device may need to be re-entered.
 
 ### Create Hotspot
 
@@ -91,7 +91,7 @@ Folders must be empty before deletion. File uploads, overwrites, moves, renames,
 
 ### Settings
 
-The settings page exposes supported device settings through `/api/settings`. Changes are saved to `/.crosspoint/settings.bin`.
+The settings page exposes supported device settings through `/api/settings`. Changes are saved to `/.crosspoint/settings.json`.
 
 ### Fonts
 
@@ -99,7 +99,7 @@ The fonts page lists installed SD-card font families and allows `.cpfont` upload
 
 ### OPDS and WiFi Management
 
-The web interface includes APIs for managing saved OPDS servers and saved WiFi credentials. Passwords are never returned by the API; the API only reports whether a password is set.
+The web interface includes APIs for managing saved OPDS servers and saved WiFi credentials. Passwords are never returned by the API; the API only reports whether a password is set. Saved passwords use device-specific validation, so password fields copied from a different reader are ignored until re-entered.
 
 ---
 

--- a/lib/KOReaderSync/KOReaderJsonIO.cpp
+++ b/lib/KOReaderSync/KOReaderJsonIO.cpp
@@ -32,11 +32,17 @@ bool load(KOReaderCredentialStore& store, const char* json, bool* needsResave) {
 
   std::string user = doc["username"] | std::string("");
 
-  bool ok = false;
-  std::string pass = obfuscation::deobfuscateFromBase64(doc["password_obf"] | "", &ok);
-  if (!ok || pass.empty()) {
+  obfuscation::DecodeStatus status = obfuscation::DecodeStatus::INVALID;
+  std::string pass = obfuscation::deobfuscateFromBase64(doc["password_obf"] | "", &status);
+  if (status == obfuscation::DecodeStatus::LEGACY && !pass.empty() && needsResave) {
+    *needsResave = true;
+  }
+  if (status == obfuscation::DecodeStatus::INVALID || status == obfuscation::DecodeStatus::EMPTY || pass.empty()) {
     pass = doc["password"] | std::string("");
     if (!pass.empty() && needsResave) *needsResave = true;
+  }
+  if (status == obfuscation::DecodeStatus::INVALID && pass.empty()) {
+    LOG_ERR("KRS", "Ignoring unreadable KOReader password");
   }
 
   store.setCredentials(user, pass);

--- a/lib/Serialization/ObfuscationUtils.cpp
+++ b/lib/Serialization/ObfuscationUtils.cpp
@@ -11,6 +11,11 @@ namespace obfuscation {
 
 namespace {
 constexpr size_t HW_KEY_LEN = 6;
+constexpr char VALIDATED_PREFIX[] = {'C', 'P', 'V', '1'};
+constexpr size_t VALIDATED_PREFIX_LEN = sizeof(VALIDATED_PREFIX);
+constexpr size_t CHECKSUM_LEN = 4;
+constexpr uint32_t FNV_OFFSET_BASIS = 2166136261UL;
+constexpr uint32_t FNV_PRIME = 16777619UL;
 
 // Simple lazy init — no thread-safety concern on single-core ESP32-C3.
 const uint8_t* getHwKey() {
@@ -21,6 +26,59 @@ const uint8_t* getHwKey() {
     initialized = true;
   }
   return key;
+}
+
+void appendUint32LE(std::string& data, uint32_t value) {
+  data.push_back(static_cast<char>(value & 0xFF));
+  data.push_back(static_cast<char>((value >> 8) & 0xFF));
+  data.push_back(static_cast<char>((value >> 16) & 0xFF));
+  data.push_back(static_cast<char>((value >> 24) & 0xFF));
+}
+
+uint32_t readUint32LE(const std::string& data, size_t offset) {
+  return static_cast<uint32_t>(static_cast<uint8_t>(data[offset])) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(data[offset + 1])) << 8) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(data[offset + 2])) << 16) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(data[offset + 3])) << 24);
+}
+
+uint32_t updateFnv1a(uint32_t hash, const uint8_t byte) {
+  hash ^= byte;
+  hash *= FNV_PRIME;
+  return hash;
+}
+
+uint32_t checksumForPlaintext(const std::string& plaintext) {
+  uint32_t hash = FNV_OFFSET_BASIS;
+  const uint8_t* key = getHwKey();
+  for (size_t i = 0; i < HW_KEY_LEN; i++) {
+    hash = updateFnv1a(hash, key[i]);
+  }
+  for (char c : plaintext) {
+    hash = updateFnv1a(hash, static_cast<uint8_t>(c));
+  }
+  return hash;
+}
+
+bool hasValidatedPrefix(const std::string& data) {
+  return data.size() >= VALIDATED_PREFIX_LEN && memcmp(data.data(), VALIDATED_PREFIX, VALIDATED_PREFIX_LEN) == 0;
+}
+
+bool decodeValidatedPayload(const std::string& payload, std::string& plaintext) {
+  if (payload.size() < VALIDATED_PREFIX_LEN + CHECKSUM_LEN) {
+    LOG_ERR("OBF", "Validated credential payload is too short");
+    return false;
+  }
+
+  const size_t checksumOffset = VALIDATED_PREFIX_LEN;
+  const uint32_t expectedChecksum = readUint32LE(payload, checksumOffset);
+  plaintext = payload.substr(VALIDATED_PREFIX_LEN + CHECKSUM_LEN);
+  if (checksumForPlaintext(plaintext) != expectedChecksum) {
+    LOG_ERR("OBF", "Validated credential checksum mismatch");
+    return false;
+  }
+
+  return true;
 }
 }  // namespace
 
@@ -40,24 +98,34 @@ void xorTransform(std::string& data, const uint8_t* key, size_t keyLen) {
 
 String obfuscateToBase64(const std::string& plaintext) {
   if (plaintext.empty()) return "";
-  std::string temp = plaintext;
-  xorTransform(temp);
-  return base64::encode(reinterpret_cast<const uint8_t*>(temp.data()), temp.size());
+  std::string payload;
+  payload.reserve(VALIDATED_PREFIX_LEN + CHECKSUM_LEN + plaintext.size());
+  payload.append(VALIDATED_PREFIX, VALIDATED_PREFIX_LEN);
+  appendUint32LE(payload, checksumForPlaintext(plaintext));
+  payload += plaintext;
+  xorTransform(payload);
+  return base64::encode(reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
 }
 
 std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
+  DecodeStatus status = DecodeStatus::INVALID;
+  std::string result = deobfuscateFromBase64(encoded, &status);
+  if (ok) *ok = (status == DecodeStatus::VALIDATED || status == DecodeStatus::LEGACY);
+  return result;
+}
+
+std::string deobfuscateFromBase64(const char* encoded, DecodeStatus* status) {
+  if (status) *status = DecodeStatus::INVALID;
   if (encoded == nullptr || encoded[0] == '\0') {
-    if (ok) *ok = false;
+    if (status) *status = DecodeStatus::EMPTY;
     return "";
   }
-  if (ok) *ok = true;
   size_t encodedLen = strlen(encoded);
   // First call: get required output buffer size
   size_t decodedLen = 0;
   int ret = mbedtls_base64_decode(nullptr, 0, &decodedLen, reinterpret_cast<const unsigned char*>(encoded), encodedLen);
   if (ret != 0 && ret != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
     LOG_ERR("OBF", "Base64 decode size query failed (ret=%d)", ret);
-    if (ok) *ok = false;
     return "";
   }
   std::string result(decodedLen, '\0');
@@ -65,11 +133,22 @@ std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
                               reinterpret_cast<const unsigned char*>(encoded), encodedLen);
   if (ret != 0) {
     LOG_ERR("OBF", "Base64 decode failed (ret=%d)", ret);
-    if (ok) *ok = false;
     return "";
   }
   result.resize(decodedLen);
+
   xorTransform(result);
+  if (hasValidatedPrefix(result)) {
+    std::string plaintext;
+    if (!decodeValidatedPayload(result, plaintext)) {
+      return "";
+    }
+
+    if (status) *status = DecodeStatus::VALIDATED;
+    return plaintext;
+  }
+
+  if (status) *status = DecodeStatus::LEGACY;
   return result;
 }
 
@@ -81,6 +160,36 @@ void selfTest() {
     std::string decoded = deobfuscateFromBase64(encoded.c_str());
     if (decoded != input) {
       LOG_ERR("OBF", "FAIL: \"%s\" -> \"%s\" -> \"%s\"", input, encoded.c_str(), decoded.c_str());
+      allPassed = false;
+    }
+  }
+  {
+    std::string legacyPlaintext = "legacy marker collision";
+    const uint8_t* key = getHwKey();
+    for (size_t i = 0; i < VALIDATED_PREFIX_LEN; i++) {
+      legacyPlaintext[i] = static_cast<char>(static_cast<uint8_t>(VALIDATED_PREFIX[i]) ^ key[i % HW_KEY_LEN]);
+    }
+    std::string legacyCiphertext = legacyPlaintext;
+    xorTransform(legacyCiphertext);
+    String legacyEncoded =
+        base64::encode(reinterpret_cast<const uint8_t*>(legacyCiphertext.data()), legacyCiphertext.size());
+
+    DecodeStatus status = DecodeStatus::INVALID;
+    std::string decoded = deobfuscateFromBase64(legacyEncoded.c_str(), &status);
+    if (status != DecodeStatus::LEGACY || decoded != legacyPlaintext) {
+      LOG_ERR("OBF", "FAIL: legacy credential marker collision was not decoded as legacy");
+      allPassed = false;
+    }
+  }
+  String encoded = obfuscateToBase64("test123");
+  if (encoded.length() > 0) {
+    std::string tampered = encoded.c_str();
+    const char replacement = tampered[tampered.size() - 1] == 'A' ? 'B' : 'A';
+    tampered[tampered.size() - 1] = replacement;
+    bool ok = true;
+    deobfuscateFromBase64(tampered.c_str(), &ok);
+    if (ok) {
+      LOG_ERR("OBF", "FAIL: tampered credential validated");
       allPassed = false;
     }
   }

--- a/lib/Serialization/ObfuscationUtils.h
+++ b/lib/Serialization/ObfuscationUtils.h
@@ -16,6 +16,13 @@
  */
 namespace obfuscation {
 
+enum class DecodeStatus : uint8_t {
+  EMPTY,
+  INVALID,
+  LEGACY,
+  VALIDATED,
+};
+
 // XOR obfuscate/deobfuscate in-place using hardware MAC key (symmetric operation)
 void xorTransform(std::string& data);
 
@@ -26,8 +33,9 @@ void xorTransform(std::string& data, const uint8_t* key, size_t keyLen);
 String obfuscateToBase64(const std::string& plaintext);
 
 // Decode base64 and de-obfuscate back to plaintext.
-// Returns empty string on invalid base64 input; sets *ok to false if decode fails.
+// Returns empty string on invalid input; sets *ok to false if decode or validation fails.
 std::string deobfuscateFromBase64(const char* encoded, bool* ok = nullptr);
+std::string deobfuscateFromBase64(const char* encoded, DecodeStatus* status);
 
 // Self-test: verifies round-trip obfuscation with hardware key. Logs PASS/FAIL.
 void selfTest();

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -222,9 +222,12 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
       const std::string fieldDefault = strPtr;  // current buffer = struct-initializer default
       std::string val;
       if (info.obfuscated) {
-        bool ok = false;
-        val = obfuscation::deobfuscateFromBase64(doc[std::string(info.key) + "_obf"] | "", &ok);
-        if (!ok || val.empty()) {
+        obfuscation::DecodeStatus status = obfuscation::DecodeStatus::INVALID;
+        val = obfuscation::deobfuscateFromBase64(doc[std::string(info.key) + "_obf"] | "", &status);
+        if (status == obfuscation::DecodeStatus::LEGACY && !val.empty() && needsResave) {
+          *needsResave = true;
+        }
+        if (status == obfuscation::DecodeStatus::INVALID || status == obfuscation::DecodeStatus::EMPTY || val.empty()) {
           val = doc[info.key] | fieldDefault;
           if (val != fieldDefault && needsResave) *needsResave = true;
         }
@@ -357,11 +360,24 @@ bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool
     if (store.credentials.size() >= store.MAX_NETWORKS) break;
     WifiCredential cred;
     cred.ssid = obj["ssid"] | std::string("");
-    bool ok = false;
-    cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok);
-    if (!ok || cred.password.empty()) {
+    if (cred.ssid.empty()) {
+      LOG_ERR("WCS", "Skipping WiFi credential with empty SSID");
+      continue;
+    }
+
+    obfuscation::DecodeStatus status = obfuscation::DecodeStatus::INVALID;
+    cred.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &status);
+    if (status == obfuscation::DecodeStatus::LEGACY && !cred.password.empty() && needsResave) {
+      *needsResave = true;
+    }
+    if (status == obfuscation::DecodeStatus::INVALID || status == obfuscation::DecodeStatus::EMPTY ||
+        cred.password.empty()) {
       cred.password = obj["password"] | std::string("");
       if (!cred.password.empty() && needsResave) *needsResave = true;
+    }
+    if (status == obfuscation::DecodeStatus::INVALID && cred.password.empty()) {
+      LOG_ERR("WCS", "Skipping WiFi credential with unreadable password: %s", cred.ssid.c_str());
+      continue;
     }
     store.credentials.push_back(cred);
   }
@@ -452,11 +468,18 @@ bool JsonSettingsIO::loadOpds(OpdsServerStore& store, const char* json, bool* ne
     server.username = obj["username"] | std::string("");
     // Try the obfuscated key first; fall back to plaintext "password" for
     // files written before obfuscation was added (or hand-edited JSON).
-    bool ok = false;
-    server.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &ok);
-    if (!ok || server.password.empty()) {
+    obfuscation::DecodeStatus status = obfuscation::DecodeStatus::INVALID;
+    server.password = obfuscation::deobfuscateFromBase64(obj["password_obf"] | "", &status);
+    if (status == obfuscation::DecodeStatus::LEGACY && !server.password.empty() && needsResave) {
+      *needsResave = true;
+    }
+    if (status == obfuscation::DecodeStatus::INVALID || status == obfuscation::DecodeStatus::EMPTY ||
+        server.password.empty()) {
       server.password = obj["password"] | std::string("");
       if (!server.password.empty() && needsResave) *needsResave = true;
+    }
+    if (status == obfuscation::DecodeStatus::INVALID && server.password.empty()) {
+      LOG_ERR("OPS", "Ignoring unreadable password for OPDS server: %s", server.name.c_str());
     }
     store.servers.push_back(std::move(server));
   }


### PR DESCRIPTION
## Summary
- add a validated wrapper around newly saved obfuscated credential payloads
- resave readable legacy credential payloads into the validated format
- ignore unreadable copied/corrupted WiFi passwords instead of treating them as usable saved credentials
- document the device-specific saved-password behavior

## Root Cause
Saved passwords were only XOR-obfuscated with the device MAC and base64 encoded. Reads could verify that the JSON/base64 shape was parseable, but not that the decoded password belonged to the current reader or was uncorrupted. A copied SD card from another device could therefore produce non-empty garbage and be treated like a saved password.

## Validation
- `pio run -e simulator`
- `pio run -e tiny`