### PR TITLE
fix: redraw carousel header after restoring cached frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The X3 clock visibility setting is now phrased as `Hide Clock`, with existing `Show Clock` preferences migrated to the matching hide behavior.
 
 ### Fixed
+- Lyra Carousel now redraws the Home header when restoring cached carousel frames so battery percentage and clock values stay current while navigating between books.
 - RoundedRaff's date shown in settings now sits lower on X3 devices instead of overlapping the battery.
 - Clear Bookmark List now asks for confirmation before deleting a book's bookmarks.
 - Clear Reading Cache now preserves per-book reading stats while continuing to leave all-time reading stats untouched.

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -1603,6 +1603,9 @@ void HomeActivity::render(RenderLock&&) {
       memcpy(frameBuffer, carouselFrames[slotIdx], renderer.getBufferSize());
       LyraCarouselTheme::setPreRenderIndex(centerIdx);
 
+      // Cached carousel frames include the header; redraw it so dynamic values
+      // like battery percentage and clock are current for every restored frame.
+      GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.homeTopPadding}, nullptr);
       GUI.drawCarouselBorder(renderer, Rect{0, metrics.homeTopPadding, pageWidth, metrics.homeCoverTileHeight},
                              recentBooks, centerIdx, inCarouselRow);
       if (!inCarouselRow) {


### PR DESCRIPTION
## Summary
- Redraw the Lyra Carousel Home header after restoring a cached carousel framebuffer.
- Add a changelog entry for the battery/clock freshness fix.

## Root Cause
Lyra Carousel caches full Home framebuffers, including the header. Navigating between carousel books can therefore restore battery percentage text that was captured when each frame was rendered, instead of showing the current battery sample.

## Validation
- `pio run -e simulator`

## Hardware Check
On X4, use Lyra Carousel, clear `/.crosspoint/home_carousel_cache.bin`, return to Home, and navigate between carousel books. The battery percentage should stay consistent across restored frames except for normal slow battery changes.