### PR TITLE
fix: suppress back release from reader settings screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Long-press reader shortcuts that open another screen no longer close or confirm it again when releasing the shortcut button.
 - RoundedRaff's header battery icon and percentage now sit lower to avoid clipping at the top edge.
 - Lyra Carousel now redraws the Home header when restoring cached carousel frames so battery percentage and clock values stay current while navigating between books.
+- Reader-launched settings screens no longer jump back two screens after pressing Back.
 
 ## [v1.3.3] - 2026-06-13
 

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -21,4 +21,9 @@ void Activity::startActivityForResult(std::unique_ptr<Activity>&& activity, Acti
 
 void Activity::setResult(ActivityResult&& result) { this->result = std::move(result); }
 
+void Activity::finishAfterBackPress() {
+  mappedInput.suppressNextBackRelease();
+  finish();
+}
+
 void Activity::finish() { activityManager.popActivity(); }

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -24,6 +24,10 @@ class Activity {
   ActivityResultHandler resultHandler;
   ActivityResult result;
 
+  // Use when a screen exits on Back press instead of Back release so the
+  // parent screen does not also receive the held button's release.
+  void finishAfterBackPress();
+
  public:
   explicit Activity(std::string name, GfxRenderer& renderer, MappedInputManager& mappedInput)
       : name(std::move(name)), renderer(renderer), mappedInput(mappedInput) {}

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -542,6 +542,7 @@ void WifiSelectionActivity::loop() {
     sConnectionAttemptLoggingActive = false;
 #endif
     WiFi.disconnect();
+    mappedInput.suppressNextBackRelease();
     onComplete(false);
     return;
   }
@@ -588,6 +589,7 @@ void WifiSelectionActivity::loop() {
       onComplete(true);
     } else if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
       // Skip saving, complete anyway
+      mappedInput.suppressNextBackRelease();
       onComplete(true);
     }
     return;
@@ -629,8 +631,13 @@ void WifiSelectionActivity::loop() {
   }
 
   if (state == WifiSelectionState::CONNECTED) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      mappedInput.suppressNextBackRelease();
+      onComplete(true);
+      return;
+    }
+
+    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
       onComplete(true);
     }
     return;
@@ -659,6 +666,7 @@ void WifiSelectionActivity::loop() {
   if (state == WifiSelectionState::NETWORK_LIST) {
     // Check for Back button to exit (cancel)
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      mappedInput.suppressNextBackRelease();
       onComplete(false);
       return;
     }

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -838,7 +838,6 @@ void FontDownloadActivity::loop() {
     }
   } else if (state_ == ERROR) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-      mappedInput.suppressNextBackRelease();
       if (manifestReloadNeeded_) {
         returnToFamilyList();
         requestUpdate();
@@ -851,7 +850,7 @@ void FontDownloadActivity::loop() {
       errorMessage_.clear();
       errorHint_.clear();
       if (families_.empty()) {
-        finish();
+        finishAfterBackPress();
       } else {
         RenderLock lock(*this);
         state_ = FAMILY_LIST;

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -770,7 +770,7 @@ bool FontDownloadActivity::isSelectedFamilyDeletable() const {
 void FontDownloadActivity::loop() {
   if (state_ == FAMILY_LIST) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-      finish();
+      finishAfterBackPress();
       return;
     }
 
@@ -838,6 +838,7 @@ void FontDownloadActivity::loop() {
     }
   } else if (state_ == ERROR) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      mappedInput.suppressNextBackRelease();
       if (manifestReloadNeeded_) {
         returnToFamilyList();
         requestUpdate();

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -103,8 +103,12 @@ void KOReaderAuthActivity::render(RenderLock&&) {
 
 void KOReaderAuthActivity::loop() {
   if (state == SUCCESS || state == FAILED) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+      finishAfterBackPress();
+      return;
+    }
+
+    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
       finish();
     }
   }

--- a/src/activities/settings/KOReaderSettingsActivity.cpp
+++ b/src/activities/settings/KOReaderSettingsActivity.cpp
@@ -29,7 +29,7 @@ void KOReaderSettingsActivity::onExit() { Activity::onExit(); }
 
 void KOReaderSettingsActivity::loop() {
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    finish();
+    finishAfterBackPress();
     return;
   }
 

--- a/src/activities/settings/StatusBarSettingsActivity.cpp
+++ b/src/activities/settings/StatusBarSettingsActivity.cpp
@@ -216,7 +216,7 @@ void StatusBarSettingsActivity::onExit() { Activity::onExit(); }
 
 void StatusBarSettingsActivity::loop() {
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    finish();
+    finishAfterBackPress();
     return;
   }
 

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -351,6 +351,7 @@ void KeyboardEntryActivity::loop() {
   }
 
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    mappedInput.suppressNextBackRelease();
     onCancel();
   }
 


### PR DESCRIPTION
## Summary
- Suppress the pending Back release when reader-launched settings screens exit on Back press.
- Apply the same handling to nested Wi-Fi, font download, KOReader, and keyboard entry flows reachable from the reader.
- Add an Unreleased changelog note for the reader navigation fix.

## Root Cause
Some child screens closed on Back press while their parent screens close on Back release. The same physical button interaction could therefore pop the child immediately, then the parent would see the release event and pop again.

## Validation
- `pio run -e simulator`
- `pio run -e default`
- `git diff --check`

## Hardware Verification
Open a book, go to Reader Menu > Reader Options > Customize Status Bar, then press Back. Expected behavior is returning to Reader Options only; pressing Back again returns to the Reader Menu.