### PR TITLE
fix: avoid oversized web multi-delete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - RoundedRaff's header battery icon and percentage now sit lower to avoid clipping at the top edge.
 - Lyra Carousel now redraws the Home header when restoring cached carousel frames so battery percentage and clock values stay current while navigating between books.
 - Reader-launched settings screens no longer jump back two screens after pressing Back.
+- Web file manager multi-delete now handles larger selections without failing after a small batch.
 
 ## [v1.3.3] - 2026-06-13
 

--- a/web/pages/files.js
+++ b/web/pages/files.js
@@ -1125,7 +1125,7 @@
     document.getElementById('deleteModal').classList.remove('open');
   }
 
-  function confirmDelete() {
+  async function confirmDelete() {
     if (!deleteItemsGlobal || deleteItemsGlobal.length === 0) {
       closeDeleteModal();
       return;
@@ -1138,23 +1138,45 @@
       return p;
     });
 
-    const body = 'paths=' + encodeURIComponent(JSON.stringify(paths));
-    fetch('/delete', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body
-    }).then(async res => {
-      if (res.ok) {
-        window.location.reload();
-      } else {
-        const text = await res.text();
-        alert('Failed to delete: ' + text);
-        closeDeleteModal();
+    const deleteBtn = document.querySelector('#deleteModal .delete-btn-confirm');
+    if (deleteBtn) {
+      deleteBtn.disabled = true;
+      deleteBtn.textContent = 'Deleting...';
+    }
+
+    const failed = [];
+    try {
+      for (const path of paths) {
+        const res = await fetch('/delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'path=' + encodeURIComponent(path)
+        });
+        if (!res.ok) {
+          const text = await res.text();
+          failed.push(path + ': ' + text);
+        }
       }
-    }).catch(() => {
+
+      if (failed.length === 0) {
+        window.location.reload();
+        return;
+      }
+
+      const shown = failed.slice(0, 3).join('\n');
+      const hiddenCount = failed.length - 3;
+      alert('Failed to delete ' + failed.length + ' item' + (failed.length === 1 ? '' : 's') + ':\n' +
+            shown + (hiddenCount > 0 ? '\n...and ' + hiddenCount + ' more' : ''));
+      closeDeleteModal();
+    } catch (_) {
       alert('Failed to delete - network error');
       closeDeleteModal();
-    });
+    } finally {
+      if (deleteBtn) {
+        deleteBtn.disabled = false;
+        deleteBtn.textContent = 'Delete';
+      }
+    }
   }
 
   // Helper to clear image picker state


### PR DESCRIPTION
## Summary
- Change the web file manager multi-delete flow to send one small delete request per selected item instead of one large `paths` payload.
- Keep the delete modal disabled while the batch is running and report partial failures without aborting the whole selection.
- Add an Unreleased changelog entry for the user-facing fix.

## Root Cause
The browser was posting all selected paths as one URL-encoded JSON array to `/delete`. With larger selections, that request can exceed the small request/parsing budget on the ESP32-C3 before the firmware deletes anything. Splitting the batch in the browser keeps each request small and reuses the existing single-path delete handler.

Fixes #269.

## Validation
- `python3 scripts/build_web.py`
- `pio run -e simulator`
- `pio run -e tiny -j1`
- `git diff --check`